### PR TITLE
feat: 🐄 (std::borrow::Cow) to reduce the cloning and copying on decod…

### DIFF
--- a/insim/src/packets/insim/msl.rs
+++ b/insim/src/packets/insim/msl.rs
@@ -50,16 +50,18 @@ impl Encodable for Msl {
         self.reqi.encode(buf, None)?;
         self.sound.encode(buf, None)?;
 
-        let msg = codepages::to_lossy_bytes(&self.msg);
+        let msg: &[u8] = &codepages::to_lossy_bytes(&self.msg);
         if msg.len() > 127 {
             return Err(EncodableError::WrongSize(
                 "Msx only supports upto 127 byte long messages".into(),
             ));
         }
-        msg.encode(buf, Some(insim_core::ser::Limit::Bytes(127)))?;
+
         // last byte must be zero
-        if msg.len() < 128 {
-            buf.put_bytes(0, 128 - msg.len());
+        let padding = 128 - msg.len();
+        buf.extend_from_slice(msg);
+        if padding > 0 {
+            buf.put_bytes(0, padding);
         }
 
         Ok(())

--- a/insim/src/packets/insim/mst.rs
+++ b/insim/src/packets/insim/mst.rs
@@ -29,18 +29,19 @@ impl Encodable for Mst {
         self.reqi.encode(buf, None)?;
         buf.put_bytes(0, 1);
 
-        let msg = codepages::to_lossy_bytes(&self.msg);
+        let msg: &[u8] = &codepages::to_lossy_bytes(&self.msg);
         if msg.len() > 63 {
             return Err(EncodableError::WrongSize(
                 "Mst only supports upto 63 byte long messages".into(),
             ));
         }
-        msg.encode(buf, Some(insim_core::ser::Limit::Bytes(63)))?;
-        // last byte must be zero
-        if msg.len() < 64 {
-            buf.put_bytes(0, 64 - msg.len());
-        }
 
+        let padding = 64 - msg.len();
+        buf.extend_from_slice(msg);
+
+        if padding > 0 {
+            buf.put_bytes(0, padding);
+        }
         Ok(())
     }
 }

--- a/insim/src/packets/insim/msx.rs
+++ b/insim/src/packets/insim/msx.rs
@@ -29,16 +29,19 @@ impl Encodable for Msx {
         self.reqi.encode(buf, None)?;
         buf.put_bytes(0, 1);
 
-        let msg = codepages::to_lossy_bytes(&self.msg);
+        let msg: &[u8] = &codepages::to_lossy_bytes(&self.msg);
         if msg.len() > 95 {
             return Err(EncodableError::WrongSize(
                 "Msx only supports upto 95 byte long messages".into(),
             ));
         }
-        msg.encode(buf, Some(insim_core::ser::Limit::Bytes(95)))?;
+
         // last byte must be zero
-        if msg.len() < 96 {
-            buf.put_bytes(0, 96 - msg.len());
+        let padding = 96 - msg.len();
+        buf.extend_from_slice(msg);
+
+        if padding > 0 {
+            buf.put_bytes(0, padding);
         }
 
         Ok(())

--- a/insim_core/tests/strings.rs
+++ b/insim_core/tests/strings.rs
@@ -1,11 +1,13 @@
+use std::borrow::Cow;
+
 use insim_core::string::{codepages, escape, unescape};
 
 #[test]
 fn test_escaping_and_unescaping() {
-    let original = "^|*:\\/?\"<>#123^945";
+    let original: Cow<str> = "^|*:\\/?\"<>#123^945".into();
 
-    let escaped = escape(original);
-    let unescaped = unescape(&escaped);
+    let escaped = escape(original.clone());
+    let unescaped = unescape(escaped.clone());
 
     assert_eq!(escaped, "^^^v^a^c^d^s^q^t^l^r^h123^945");
     assert_eq!(unescaped, original);

--- a/insim_pth/src/lib.rs
+++ b/insim_pth/src/lib.rs
@@ -33,6 +33,9 @@ pub enum Error {
 
     #[error("Failed to decode packet: {0:?}")]
     Decoding(#[from] DecodableError),
+
+    #[error("Remaining bytes after decoding, possibly broken file?")]
+    UnexpectedRemainingBytes,
 }
 
 impl From<std::io::Error> for Error {
@@ -153,6 +156,12 @@ impl Pth {
         let mut data = insim_core::bytes::BytesMut::new();
         data.extend_from_slice(&buffer);
 
-        Ok(Self::decode(&mut data, None)?)
+        let result = Self::decode(&mut data, None)?;
+
+        if data.remaining() > 0 {
+            return Err(Error::UnexpectedRemainingBytes);
+        }
+
+        Ok(result)
     }
 }

--- a/insim_smx/src/lib.rs
+++ b/insim_smx/src/lib.rs
@@ -25,6 +25,9 @@ pub enum Error {
 
     #[error("Failed to decode packet: {0:?}")]
     Decoding(#[from] DecodableError),
+
+    #[error("Remaining bytes after decoding, possibly broken file?")]
+    UnexpectedRemainingBytes,
 }
 
 impl From<std::io::Error> for Error {
@@ -127,6 +130,12 @@ impl Smx {
         let mut data = insim_core::bytes::BytesMut::new();
         data.extend_from_slice(&buffer);
 
-        Ok(Self::decode(&mut data, None)?)
+        let result = Self::decode(&mut data, None)?;
+
+        if data.remaining() > 0 {
+            return Err(Error::UnexpectedRemainingBytes);
+        }
+
+        Ok(result)
     }
 }

--- a/insim_smx/tests/smx.rs
+++ b/insim_smx/tests/smx.rs
@@ -6,7 +6,8 @@ fn test_smx_decode() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("./tests/Autocross_3DH.smx");
     let p = Smx::from_file(&path).expect("Expected SMX file to be parsed");
 
-    assert!(p.objects.len() == p.num_objects as usize);
-
-    assert!(p.checkpoint_object_index.len() == p.num_checkpoints as usize);
+    assert_eq!(p.num_objects, 1666);
+    assert_eq!(p.objects.len(), p.num_objects as usize);
+    assert_eq!(p.checkpoint_object_index.len(), p.num_checkpoints as usize);
+    assert_eq!(p.track, "Autocross");
 }


### PR DESCRIPTION
…e, try to optimise the string encoding and encoding to do less work if possible

Fixes #98 