### PR TITLE
fix(insim): allow udpport to be explicitly set

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -20,3 +20,5 @@ Each example is setup as its own crate so its dependencies are clear.
 - `simple-outsim` - Basic outsim usage.
 - `simple-outgauge` - Basic outgauge usage.
 - `pth2svg` - Convert a LFS PTH file to an SVG.
+- `ssg-manual` - Handle split TCP and UDP connection to LFS, manually, allowing you to receive
+  Mci, Nlp, Outsim and Outgauge packets via UDP, and everything else via TCP.

--- a/examples/ssg-manual/Cargo.toml
+++ b/examples/ssg-manual/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "ssg-manual"
+version = "0.1.0-unreleased"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+anyhow = "1.0.86"
+bytes = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+insim = { path = "../../insim", default-features = false, features = ["tokio"] }
+outgauge = { path = "../../outgauge" }
+outsim = { path = "../../outsim" }
+tokio = { workspace = true, features = ["full"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/examples/ssg-manual/README.md
+++ b/examples/ssg-manual/README.md
@@ -1,0 +1,7 @@
+# ssg-manual
+
+Demonstration of how to handle split TCP and UDP connection to LFS, manually, allowing you to receive Mci, Nlp, Outsim and Outgauge packets via UDP, and everything else via TCP.
+
+## Usage
+
+- Check `cargo run -- --help`

--- a/examples/ssg-manual/src/main.rs
+++ b/examples/ssg-manual/src/main.rs
@@ -1,0 +1,104 @@
+//! High level example of using a combination of TCP and UDP.
+use std::{net::SocketAddr, time::Duration};
+
+use bytes::{Buf, Bytes, BytesMut};
+use clap::Parser;
+use insim::{Packet, core::Decode, insim::SmallType};
+use outgauge::Outgauge;
+use outsim::OutsimPack;
+use tokio::net::UdpSocket;
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+#[command(propagate_version = true)]
+struct Cli {
+    #[arg(long)]
+    /// host:port of LFS to connect to
+    addr: SocketAddr,
+
+    #[arg(long)]
+    /// host:port to bind a udp listener to.
+    udp_listen_addr: SocketAddr,
+}
+
+fn setup_tracing_subscriber() {
+    // Setup with a default log level of INFO RUST_LOG is unset
+    tracing_subscriber::fmt::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+}
+
+#[tokio::main]
+pub async fn main() -> anyhow::Result<()> {
+    // Setup tracing_subcriber with some sane defaults
+    setup_tracing_subscriber();
+
+    // Parse our command line arguments, using clap
+    let cli = Cli::parse();
+
+    let udp = UdpSocket::bind(cli.udp_listen_addr).await?;
+    // Make a buffer for the UdpSocket, we'll reuse this across recv_from calls
+    let mut buf = [0; 1024];
+
+    // Make our TCP connection
+    let mut connection = insim::tcp(cli.addr)
+        .isi_flag_mci(true)
+        .isi_flag_con(true)
+        .isi_flag_obh(true)
+        .isi_flag_axm_load(true)
+        .isi_flag_axm_edit(true)
+        .isi_interval(Duration::from_secs(1))
+        // Force the UDP port, so that it's sent to our socket
+        .isi_udpport(cli.udp_listen_addr.port())
+        .connect_async()
+        .await?;
+
+    // Establish a connection
+    tracing::info!("Connected!");
+
+    // Start sending gauges (outgauge)
+    connection
+        .write(SmallType::Ssg(Duration::from_secs(1)))
+        .await?;
+
+    // Start sending positions (outsim)
+    connection
+        .write(SmallType::Ssp(Duration::from_secs(1)))
+        .await?;
+
+    loop {
+        tokio::select! {
+            packet = connection.read() => {
+                let packet = packet?;
+                tracing::info!("{:?}", packet);
+            },
+            res = udp.recv_from(&mut buf) => {
+                let (amt, src) = res?;
+                let mut buf: Bytes = BytesMut::from(&buf[..amt]).freeze();
+
+                if amt == 92 {
+                    // Conventionally it's outgauge
+                    let packet = Outgauge::decode(&mut buf)?;
+                    tracing::info!("outgauge: from={:?}, data={:?}", src, packet);
+                } else if amt == 64 {
+                    // Conventionally it's outsim
+                    let packet = OutsimPack::decode(&mut buf)?;
+                    tracing::info!("outsim: from={:?}, data={:?}", src, packet);
+                } else if amt > 1 {
+                    // Otherwise it's probably a Mci or Nlp packet
+                    //
+                    // XXX: we need to chop off the first byte, which is the length of the packet.
+                    // That's normally handled internally
+                    // by the insim crate.
+                    buf.advance(1);
+                    let packet = Packet::decode(&mut buf)?;
+                    tracing::info!("insim: from={:?}, data={:?}", src, packet);
+                }
+            }
+        }
+    }
+}

--- a/insim/src/builder.rs
+++ b/insim/src/builder.rs
@@ -58,6 +58,7 @@ pub struct Builder {
     isi_interval: Option<Duration>,
     isi_iname: Option<String>,
     isi_reqi: RequestId,
+    isi_udpport: Option<u16>,
 
     // Choosing to use separate fields with a prefix, rather than an enum because when this was
     // originally implemented it supported LFSW Relay, which no longer exists, and if you were to do
@@ -90,6 +91,7 @@ impl Default for Builder {
             isi_iname: None,
             isi_interval: None,
             isi_reqi: RequestId(1),
+            isi_udpport: None,
         }
     }
 }
@@ -247,6 +249,26 @@ impl Builder {
         self
     }
 
+    /// Explicitly set the udpport to be used in the [crate::Packet::Isi] packet during connection
+    /// handshake.
+    ///
+    /// If you explicitly set this then it will override any values derived from the `udp_local_address`.
+    /// You may wish to do this in one of 2 scenarios:
+    /// - NAT/PAT (read: port forwarding) reasons
+    /// - You want to receive positional and other information over UDP, whilst using TCP.
+    ///
+    /// If you choose to use a combination of Tcp and Udp (insim protocol dictates that if a udpport is provided
+    /// then [crate::Packet::Mci], [crate::Packet::Nlp], Outgauge and Outsim packets will be sent to the
+    /// udpport) be aware that this library *does not* currently automatically handle this protocol split for
+    /// you. You **must** spawn the relevant UdpSocket by hand. You can find an example of this in
+    /// the examples/ssg-manual/ directory.
+    ///
+    /// This may change in future versions.
+    pub fn isi_udpport<P: Into<Option<u16>>>(mut self, udpport: P) -> Self {
+        self.isi_udpport = udpport.into();
+        self
+    }
+
     /// Create a [crate::insim::Isi] from this configuration.
     pub fn isi(&self, udpport: Option<u16>) -> Isi {
         Isi {
@@ -283,7 +305,7 @@ impl Builder {
                     stream.set_nonblocking(true)?;
                 }
                 let mut stream: BlockingFramed = stream.into();
-                stream.write(self.isi(None))?;
+                stream.write(self.isi(self.isi_udpport))?;
 
                 Ok(stream)
             },
@@ -298,7 +320,8 @@ impl Builder {
                     stream.set_nonblocking(true)?;
                 }
 
-                let isi = self.isi(Some(local.port()));
+                let port = self.isi_udpport.unwrap_or(local.port());
+                let isi = self.isi(Some(port));
 
                 let mut stream: BlockingFramed = stream.into();
                 stream.write(isi)?;
@@ -322,7 +345,7 @@ impl Builder {
                 let stream = tokio::net::TcpStream::from_std(stream)?;
 
                 let mut stream: AsyncFramed = stream.into();
-                stream.write(self.isi(None)).await?;
+                stream.write(self.isi(self.isi_udpport)).await?;
 
                 Ok(stream)
             },
@@ -335,7 +358,8 @@ impl Builder {
 
                 let stream = tokio::net::UdpSocket::from_std(stream)?;
 
-                let isi = self.isi(Some(local.port()));
+                let port = self.isi_udpport.unwrap_or(local.port());
+                let isi = self.isi(Some(port));
 
                 let mut stream: AsyncFramed = stream.into();
                 stream.write(isi).await?;


### PR DESCRIPTION
This is an initial version for `main`. I **may** add a TcpAndUdp transport. _Maybe_.

This initial version will be backported to the current stable release.

Partially fixes #339