### PR TITLE
refactor!(insim,insim_core,outgauge): units

### DIFF
--- a/examples/clockwork-carnage/src/games/bomb/handlers.rs
+++ b/examples/clockwork-carnage/src/games/bomb/handlers.rs
@@ -414,7 +414,7 @@ pub(super) async fn on_con(
     ui: BombUi,
 ) -> Result<(), AppError> {
     let now = Instant::now();
-    let mps = con.spclose.to_meters_per_sec();
+    let mps = con.spclose.to_metres_per_sec();
     let mut any_hit = false;
     for plid in [con.a.plid, con.b.plid] {
         let result = state.write().on_collision(plid, mps, now);

--- a/examples/live-delta/src/main.rs
+++ b/examples/live-delta/src/main.rs
@@ -220,7 +220,7 @@ pub fn main() -> Result<()> {
                 if let Some(i) = info {
                     // deal with the fact that we cant precisely know when the race starts with the
                     // RST, so we should record only when we've started moving.
-                    if i.speed.to_meters_per_sec() < 1.0 {
+                    if i.speed.to_metres_per_sec() < 1.0 {
                         continue;
                     }
                     pos = i.xyz.to_vec3_metres();

--- a/examples/marquee/src/main.rs
+++ b/examples/marquee/src/main.rs
@@ -56,7 +56,7 @@ use glam::DVec3;
 use insim::{
     Packet, WithRequestId,
     core::{
-        heading::Heading,
+        heading::ObjectHeading,
         object::{ObjectCoordinate, ObjectInfo, chalk, concrete, letterboard_rb, painted, tyres},
     },
     identifiers::PlayerId,
@@ -66,11 +66,11 @@ use insim::{
 fn position_text_common(
     text: &str,
     center: DVec3,
-    heading: Heading,
+    heading: ObjectHeading,
     spacing_meters: f64,
     forward_meters: f64,
     elapsed: Duration,
-) -> impl Iterator<Item = (usize, char, DVec3, Heading)> {
+) -> impl Iterator<Item = (usize, char, DVec3, ObjectHeading)> {
     const SPEED: f64 = 1.0;
     const MAX_VISIBLE: f64 = 10.0;
     const PADDING: usize = 2;
@@ -99,7 +99,7 @@ fn position_text_common(
 fn position_letterboard(
     text: &str,
     center: DVec3,
-    heading: Heading,
+    heading: ObjectHeading,
     spacing_meters: f64,
     forward_meters: f64,
     elapsed: Duration,
@@ -121,7 +121,7 @@ fn position_letterboard(
         Some(ObjectInfo::LetterboardRB(letterboard_rb::LetterboardRB {
             xyz: ObjectCoordinate::from_dvec3_metres(position),
             character: letter,
-            heading: Heading::from_radians(heading.to_radians() + std::f64::consts::PI),
+            heading: ObjectHeading::from_radians(heading.to_radians() + std::f64::consts::PI),
             colour: letterboard_rb::LetterboardRBColour::Red,
             floating: false,
         }))
@@ -132,7 +132,7 @@ fn position_letterboard(
 fn position_painted(
     text: &str,
     center: DVec3,
-    heading: Heading,
+    heading: ObjectHeading,
     spacing_meters: f64,
     forward_meters: f64,
     elapsed: Duration,
@@ -154,7 +154,7 @@ fn position_painted(
         Some(ObjectInfo::PaintLetters(painted::Letters {
             xyz: ObjectCoordinate::from_dvec3_metres(position),
             character: letter,
-            heading: Heading::from_radians(heading.to_radians()),
+            heading: ObjectHeading::from_radians(heading.to_radians()),
             colour: painted::PaintColour::Yellow,
             floating: false,
         }))
@@ -164,7 +164,7 @@ fn position_painted(
 
 fn position_tyrestack_circle(
     center: DVec3,
-    heading: Heading,
+    heading: ObjectHeading,
     radius_metres: f64,
     elapsed: Duration,
     max: u8,
@@ -201,7 +201,7 @@ fn position_tyrestack_circle(
         .collect()
 }
 
-pub fn generate_checkpoint_signal(location: DVec3, heading: Heading) -> Vec<ObjectInfo> {
+pub fn generate_checkpoint_signal(location: DVec3, heading: ObjectHeading) -> Vec<ObjectInfo> {
     use std::f64::consts::FRAC_PI_2;
 
     // Structure: (Local Position, The Object with Local Rotation)
@@ -216,7 +216,7 @@ pub fn generate_checkpoint_signal(location: DVec3, heading: Heading) -> Vec<Obje
                 x: concrete::Size::ThreeQuarter,
                 y: concrete::Size::ThreeQuarter,
                 height: concrete::ConcreteHeight::M4_00,
-                heading: Heading::from_radians(0.0),
+                heading: ObjectHeading::from_radians(0.0),
             }),
         ),
         (
@@ -226,7 +226,7 @@ pub fn generate_checkpoint_signal(location: DVec3, heading: Heading) -> Vec<Obje
                 x: concrete::Size::ThreeQuarter,
                 y: concrete::Size::ThreeQuarter,
                 height: concrete::ConcreteHeight::M2_25,
-                heading: Heading::from_radians(0.0),
+                heading: ObjectHeading::from_radians(0.0),
             }),
         ),
         // LEFT Arms (Offset 1.70m Right, Rotated -90 deg) --
@@ -237,7 +237,7 @@ pub fn generate_checkpoint_signal(location: DVec3, heading: Heading) -> Vec<Obje
                 colour: concrete::ConcreteColour::Yellow,
                 length: concrete::ConcreteWidthLength::Four,
                 pitch: concrete::ConcretePitch::Deg42,
-                heading: Heading::from_radians(-FRAC_PI_2), // Facing Right
+                heading: ObjectHeading::from_radians(-FRAC_PI_2), // Facing Right
             }),
         ),
         (
@@ -247,7 +247,7 @@ pub fn generate_checkpoint_signal(location: DVec3, heading: Heading) -> Vec<Obje
                 colour: concrete::ConcreteColour::Red,
                 length: concrete::ConcreteWidthLength::Four,
                 pitch: concrete::ConcretePitch::Deg42,
-                heading: Heading::from_radians(-FRAC_PI_2),
+                heading: ObjectHeading::from_radians(-FRAC_PI_2),
             }),
         ),
         (
@@ -257,7 +257,7 @@ pub fn generate_checkpoint_signal(location: DVec3, heading: Heading) -> Vec<Obje
                 colour: concrete::ConcreteColour::Blue,
                 length: concrete::ConcreteWidthLength::Four,
                 pitch: concrete::ConcretePitch::Deg42,
-                heading: Heading::from_radians(-FRAC_PI_2),
+                heading: ObjectHeading::from_radians(-FRAC_PI_2),
             }),
         ),
         // Chalk line on floor
@@ -298,7 +298,7 @@ pub fn generate_checkpoint_signal(location: DVec3, heading: Heading) -> Vec<Obje
                 x: concrete::Size::ThreeQuarter,
                 y: concrete::Size::ThreeQuarter,
                 height: concrete::ConcreteHeight::M4_00,
-                heading: Heading::from_radians(0.0),
+                heading: ObjectHeading::from_radians(0.0),
             }),
         ),
         (
@@ -308,7 +308,7 @@ pub fn generate_checkpoint_signal(location: DVec3, heading: Heading) -> Vec<Obje
                 x: concrete::Size::ThreeQuarter,
                 y: concrete::Size::ThreeQuarter,
                 height: concrete::ConcreteHeight::M2_25,
-                heading: Heading::from_radians(0.0),
+                heading: ObjectHeading::from_radians(0.0),
             }),
         ),
         // LEFT Arms (Offset 1.70m Right, Rotated 90 deg) --
@@ -319,7 +319,7 @@ pub fn generate_checkpoint_signal(location: DVec3, heading: Heading) -> Vec<Obje
                 colour: concrete::ConcreteColour::Yellow,
                 length: concrete::ConcreteWidthLength::Four,
                 pitch: concrete::ConcretePitch::Deg42,
-                heading: Heading::from_radians(FRAC_PI_2), // Facing LEFT
+                heading: ObjectHeading::from_radians(FRAC_PI_2), // Facing LEFT
             }),
         ),
         (
@@ -329,7 +329,7 @@ pub fn generate_checkpoint_signal(location: DVec3, heading: Heading) -> Vec<Obje
                 colour: concrete::ConcreteColour::Red,
                 length: concrete::ConcreteWidthLength::Four,
                 pitch: concrete::ConcretePitch::Deg42,
-                heading: Heading::from_radians(FRAC_PI_2),
+                heading: ObjectHeading::from_radians(FRAC_PI_2),
             }),
         ),
         (
@@ -339,7 +339,7 @@ pub fn generate_checkpoint_signal(location: DVec3, heading: Heading) -> Vec<Obje
                 colour: concrete::ConcreteColour::Blue,
                 length: concrete::ConcreteWidthLength::Four,
                 pitch: concrete::ConcretePitch::Deg42,
-                heading: Heading::from_radians(FRAC_PI_2),
+                heading: ObjectHeading::from_radians(FRAC_PI_2),
             }),
         ),
     ];
@@ -370,10 +370,10 @@ pub fn generate_checkpoint_signal(location: DVec3, heading: Heading) -> Vec<Obje
             // We update the 'kind' in place by adding the global heading to its local heading
             match &mut kind {
                 ObjectInfo::ConcretePillar(p) => {
-                    p.heading = Heading::from_radians(global_rad + p.heading.to_radians());
+                    p.heading = ObjectHeading::from_radians(global_rad + p.heading.to_radians());
                 },
                 ObjectInfo::ConcreteSlabWall(w) => {
-                    w.heading = Heading::from_radians(global_rad + w.heading.to_radians());
+                    w.heading = ObjectHeading::from_radians(global_rad + w.heading.to_radians());
                 },
                 _ => {}, // Handle other types if necessary
             }
@@ -446,7 +446,8 @@ pub async fn main() -> Result<()> {
         },
         Mode::Signal { x, y, z, heading } => {
             let center = DVec3::new(*x, *y, *z);
-            last_objects = generate_checkpoint_signal(center, Heading::from_radians(*heading));
+            last_objects =
+                generate_checkpoint_signal(center, ObjectHeading::from_radians(*heading));
 
             connection
                 .write(Axm {
@@ -495,19 +496,19 @@ pub async fn main() -> Result<()> {
                                 text,
                             } => {
                                 let center = DVec3::new(*x, *y, *z);
-                                let dir = Heading::from_radians(*heading);
+                                let dir = ObjectHeading::from_radians(*heading);
                                 last_objects = position_letterboard(&text, center, dir, 1.0, 10.0, started.elapsed());
                             },
                             Mode::Painted {
                                 x, y, z, heading, text
                             } => {
                                 let center = DVec3::new(*x, *y, *z);
-                                let dir = Heading::from_radians(*heading);
+                                let dir = ObjectHeading::from_radians(*heading);
                                 last_objects = position_painted(&text, center, dir, 1.0, 10.0, started.elapsed());
                             },
                             Mode::Circle { x, y, z, heading, radius, count } => {
                                 let center = DVec3::new(*x, *y, *z);
-                                let dir = Heading::from_radians(*heading);
+                                let dir = ObjectHeading::from_radians(*heading);
                                 last_objects = position_tyrestack_circle(center, dir, *radius, started.elapsed(), *count);
                             },
                             _ => {

--- a/examples/prefabs/src/main.rs
+++ b/examples/prefabs/src/main.rs
@@ -4,7 +4,7 @@ use std::{fmt, net::SocketAddr, path::PathBuf, time::Duration};
 use clap::Parser;
 use insim::{
     Packet, WithRequestId,
-    core::heading::Heading,
+    core::heading::ObjectHeading,
     identifiers::{ConnectionId, RequestId},
     insim::{Axm, BfnType, Cpp, ObjectInfo, PmoAction, PmoFlags, TinyType, TtcType},
 };
@@ -100,7 +100,7 @@ enum SpawnOrigin {
         roll_degrees: f64,
     },
     Nudge {
-        heading: Heading,
+        heading: ObjectHeading,
         distance_metres: f64,
     },
     JiggleSelection,
@@ -140,13 +140,13 @@ impl fmt::Display for SpawnOrigin {
                 heading,
                 distance_metres,
             } => {
-                let heading = if *heading == Heading::NORTH {
+                let heading = if *heading == ObjectHeading::NORTH {
                     "north"
-                } else if *heading == Heading::SOUTH {
+                } else if *heading == ObjectHeading::SOUTH {
                     "south"
-                } else if *heading == Heading::EAST {
+                } else if *heading == ObjectHeading::EAST {
                     "east"
-                } else if *heading == Heading::WEST {
+                } else if *heading == ObjectHeading::WEST {
                     "west"
                 } else {
                     "unknown"
@@ -495,7 +495,8 @@ pub async fn main() -> anyhow::Result<()> {
                     Packet::Cpp(cpp) => {
                         state.last_cpp = cpp.clone();
                         if state.compass_visible {
-                            let next = Some(tools::compass::generate(cpp.h, COMPASS_WIDTH));
+                            let next =
+                                Some(tools::compass::generate(cpp.h.to_degrees(), COMPASS_WIDTH));
 
                             if state.compass_text != next {
                                 state.compass_text = next;

--- a/examples/prefabs/src/tools/camera.rs
+++ b/examples/prefabs/src/tools/camera.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use insim::{
-    core::heading::Heading,
+    core::heading::{HeadingU16, ObjectHeading},
     identifiers::{PlayerId, RequestId},
     insim::{Cpp, ObjectInfo, StaFlags},
 };
@@ -19,8 +19,9 @@ pub fn get_top_down_view(selection: &[ObjectInfo], last_cpp: &Cpp) -> Option<Cpp
     cpp.pos.z = (100.0 * 65536.0) as i32;
 
     // Look down
-    // Heading matches object heading
-    cpp.h = target.heading().unwrap_or(Heading::NORTH);
+    // Heading matches object heading (ObjectHeading -> HeadingU16 via degrees)
+    let target_degrees = target.heading().map(|h| h.to_degrees()).unwrap_or(0.0);
+    cpp.h = HeadingU16::from_degrees(target_degrees);
     // Pitch 90 degrees down. 65536 = 360 deg. 90 deg = 16384.
     cpp.p = 16384;
     cpp.r = 0;
@@ -37,7 +38,7 @@ pub fn get_top_down_view(selection: &[ObjectInfo], last_cpp: &Cpp) -> Option<Cpp
 pub fn get_side_view(selection: &[ObjectInfo], last_cpp: &Cpp) -> Option<Cpp> {
     let target = get_target(selection)?;
     let pos_m = target.position().xyz_metres();
-    let heading = target.heading().unwrap_or(Heading::NORTH);
+    let heading = target.heading().unwrap_or(ObjectHeading::NORTH);
 
     // Place camera 90 degrees to the left of the object heading, 5m away
     // Heading + 90 degrees
@@ -52,7 +53,7 @@ pub fn get_side_view(selection: &[ObjectInfo], last_cpp: &Cpp) -> Option<Cpp> {
     let cam_z = pos_m.2 as f64; // Align to height of object
 
     // Camera look direction: Look back at object.
-    let cam_h = Heading::from_radians(heading.to_radians() - std::f64::consts::FRAC_PI_2);
+    let cam_h = HeadingU16::from_radians(heading.to_radians() - std::f64::consts::FRAC_PI_2);
 
     let mut cpp = Cpp::default();
     cpp.reqi = RequestId(0);

--- a/examples/prefabs/src/tools/compass.rs
+++ b/examples/prefabs/src/tools/compass.rs
@@ -1,6 +1,8 @@
-use insim::{Colour, core::heading::Heading};
+use insim::Colour;
 
-pub fn generate(heading: Heading, width: usize) -> String {
+/// Render a scrolling compass tape centred on `degrees` (any range; wrapped to
+/// `[0, 360)` internally).
+pub fn generate(degrees: f64, width: usize) -> String {
     if width == 0 {
         return String::new();
     }
@@ -19,7 +21,7 @@ pub fn generate(heading: Heading, width: usize) -> String {
     }
 
     let tape_len = tape.len();
-    let degrees = heading.normalize().to_degrees();
+    let degrees = degrees.rem_euclid(360.0);
 
     // map degrees to the tape index
     // total indices = 8 labels + (8 * 4 dashes) = 40 total points

--- a/examples/prefabs/src/tools/grid.rs
+++ b/examples/prefabs/src/tools/grid.rs
@@ -2,7 +2,7 @@ use anyhow::{Result, ensure};
 use glam::{DVec2, DVec3};
 use insim::{
     core::{
-        heading::Heading,
+        heading::ObjectHeading,
         object::{
             ObjectCoordinate, pit::PitStopBox, pit_start_point::PitStartPoint,
             start_position::StartPosition,
@@ -79,7 +79,7 @@ fn mode_max_index(mode: GridMode) -> usize {
 fn make_object(
     mode: GridMode,
     pos: DVec3,
-    heading: Heading,
+    heading: ObjectHeading,
     floating: bool,
     index: u8,
 ) -> ObjectInfo {
@@ -121,7 +121,7 @@ fn build_flat(selection: &[ObjectInfo], config: BuildConfig) -> Result<Vec<Objec
 
     let prototype = selection.first().unwrap();
     let origin = prototype.position().to_dvec3_metres();
-    let heading = prototype.heading().unwrap_or(Heading::NORTH);
+    let heading = prototype.heading().unwrap_or(ObjectHeading::NORTH);
     let floating = prototype.floating().unwrap_or(false);
     let z = origin.z;
 
@@ -163,7 +163,7 @@ fn build_spline(selection: &[ObjectInfo], config: BuildConfig) -> Result<Vec<Obj
     );
 
     let prototype = selection.first().unwrap();
-    let proto_heading = prototype.heading().unwrap_or(Heading::NORTH);
+    let proto_heading = prototype.heading().unwrap_or(ObjectHeading::NORTH);
     let floating = prototype.floating().unwrap_or(false);
 
     let steps_per_segment = 100usize;

--- a/examples/prefabs/src/tools/jiggle.rs
+++ b/examples/prefabs/src/tools/jiggle.rs
@@ -1,4 +1,4 @@
-use insim::{core::heading::Heading, insim::ObjectInfo};
+use insim::{core::heading::ObjectHeading, insim::ObjectInfo};
 use noise::{NoiseFn, Perlin};
 use rand_distr::{Distribution, Normal};
 
@@ -34,7 +34,7 @@ pub fn jiggle(
         // 3. Combine and Apply
         let final_rads = current_rads + spatial_jiggle + individual_jiggle;
         if let Some(heading) = new_obj.heading_mut() {
-            *heading = Heading::from_radians(final_rads);
+            *heading = ObjectHeading::from_radians(final_rads);
         }
 
         output.push(new_obj);

--- a/examples/prefabs/src/tools/mirror.rs
+++ b/examples/prefabs/src/tools/mirror.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, ensure};
 use glam::DVec2;
-use insim::{core::heading::Heading, insim::ObjectInfo};
+use insim::{core::heading::ObjectHeading, insim::ObjectInfo};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MirrorAxis {
@@ -44,7 +44,7 @@ pub fn build(selection: &[ObjectInfo], axis: MirrorAxis) -> Result<Vec<ObjectInf
                     MirrorAxis::X => std::f64::consts::PI - h,
                     MirrorAxis::Y => -h,
                 };
-                *heading = Heading::from_radians(new_h);
+                *heading = ObjectHeading::from_radians(new_h);
             }
 
             obj

--- a/examples/prefabs/src/tools/nudge.rs
+++ b/examples/prefabs/src/tools/nudge.rs
@@ -1,10 +1,14 @@
 use glam::DVec3;
 use insim::{
-    core::{heading::Heading, object::ObjectCoordinate},
+    core::{heading::ObjectHeading, object::ObjectCoordinate},
     insim::ObjectInfo,
 };
 
-pub fn nudge(selection: &[ObjectInfo], heading: Heading, distance_metres: f64) -> Vec<ObjectInfo> {
+pub fn nudge(
+    selection: &[ObjectInfo],
+    heading: ObjectHeading,
+    distance_metres: f64,
+) -> Vec<ObjectInfo> {
     let mut output = Vec::with_capacity(selection.len());
     let rads = heading.to_radians();
     let translation = DVec3::new(rads.sin(), -rads.cos(), 0.0) * distance_metres;

--- a/examples/prefabs/src/tools/painted_letters.rs
+++ b/examples/prefabs/src/tools/painted_letters.rs
@@ -1,12 +1,12 @@
 use insim::{
     core::{
-        heading::Heading,
+        heading::ObjectHeading,
         object::{ObjectCoordinate, painted},
     },
     insim::ObjectInfo,
 };
 
-pub fn build(text: &str, anchor: ObjectCoordinate, heading: Heading) -> Vec<ObjectInfo> {
+pub fn build(text: &str, anchor: ObjectCoordinate, heading: ObjectHeading) -> Vec<ObjectInfo> {
     const SPACING_RAW_UNITS: i32 = 16;
     const PADDING_SLOTS: i32 = 2;
 

--- a/examples/prefabs/src/tools/radial_array.rs
+++ b/examples/prefabs/src/tools/radial_array.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, ensure};
 use glam::{DMat2, DVec2};
-use insim::{core::heading::Heading, insim::ObjectInfo};
+use insim::{core::heading::ObjectHeading, insim::ObjectInfo};
 
 /// Arrange `count` copies of `selection` evenly around a circle.
 ///
@@ -61,7 +61,7 @@ pub fn build(
             p.y = crate::clamp_i16((placed.y * 16.0).round() as i32);
 
             if let Some(heading) = new_obj.heading_mut() {
-                *heading = Heading::from_radians(heading.to_radians() + angle);
+                *heading = ObjectHeading::from_radians(heading.to_radians() + angle);
             }
 
             result.push(new_obj);

--- a/examples/prefabs/src/tools/ramp.rs
+++ b/examples/prefabs/src/tools/ramp.rs
@@ -2,7 +2,7 @@ use anyhow::{Result, ensure};
 use glam::DVec3;
 use insim::{
     core::{
-        heading::Heading,
+        heading::ObjectHeading,
         object::{
             ObjectCoordinate,
             concrete::{
@@ -159,9 +159,9 @@ pub fn build(selection: &[ObjectInfo], config: BuildConfig) -> Result<Vec<Object
             RampMode::AcrossPath => {
                 let quarter_turn = std::f64::consts::FRAC_PI_2;
                 let final_heading = if current_bank_angle < 0.0 {
-                    Heading::from_radians(chord_heading.to_radians() - quarter_turn)
+                    ObjectHeading::from_radians(chord_heading.to_radians() - quarter_turn)
                 } else {
-                    Heading::from_radians(chord_heading.to_radians() + quarter_turn)
+                    ObjectHeading::from_radians(chord_heading.to_radians() + quarter_turn)
                 };
 
                 let fwd = spline::heading_to_forward(chord_heading);
@@ -259,7 +259,7 @@ fn default_slab() -> ConcreteSlab {
         width: ConcreteWidthLength::Four,
         length: ConcreteWidthLength::Four,
         pitch: ConcretePitch::Deg0,
-        heading: Heading::NORTH,
+        heading: ObjectHeading::NORTH,
     }
 }
 
@@ -299,7 +299,7 @@ fn height_from_step(step: u8) -> ConcreteHeight {
 }
 
 /// Absolute angular difference between two headings, normalised to [0, π].
-fn heading_delta_radians(a: Heading, b: Heading) -> f64 {
+fn heading_delta_radians(a: ObjectHeading, b: ObjectHeading) -> f64 {
     let mut diff = a.to_radians() - b.to_radians();
     while diff > std::f64::consts::PI {
         diff -= 2.0 * std::f64::consts::PI;

--- a/examples/prefabs/src/tools/rotate.rs
+++ b/examples/prefabs/src/tools/rotate.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, ensure};
 use glam::{DMat2, DVec2};
-use insim::{core::heading::Heading, insim::ObjectInfo};
+use insim::{core::heading::ObjectHeading, insim::ObjectInfo};
 
 pub fn build(selection: &[ObjectInfo], degrees: f64) -> Result<Vec<ObjectInfo>> {
     ensure!(
@@ -35,7 +35,7 @@ pub fn build(selection: &[ObjectInfo], degrees: f64) -> Result<Vec<ObjectInfo>> 
             pos.y = crate::clamp_i16((final_pos.y * 16.0).round() as i32);
 
             if let Some(heading) = obj.heading_mut() {
-                *heading = Heading::from_radians(heading.to_radians() + radians);
+                *heading = ObjectHeading::from_radians(heading.to_radians() + radians);
             }
 
             obj

--- a/examples/prefabs/src/tools/rotate_each.rs
+++ b/examples/prefabs/src/tools/rotate_each.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, ensure};
-use insim::{core::heading::Heading, insim::ObjectInfo};
+use insim::{core::heading::ObjectHeading, insim::ObjectInfo};
 
 /// Rotates each object's heading in place by `degrees`, without moving positions.
 pub fn build(selection: &[ObjectInfo], degrees: f64) -> Result<Vec<ObjectInfo>> {
@@ -19,7 +19,7 @@ pub fn build(selection: &[ObjectInfo], degrees: f64) -> Result<Vec<ObjectInfo>> 
         .cloned()
         .map(|mut obj| {
             if let Some(heading) = obj.heading_mut() {
-                *heading = Heading::from_radians(heading.to_radians() + radians);
+                *heading = ObjectHeading::from_radians(heading.to_radians() + radians);
             }
             obj
         })

--- a/examples/prefabs/src/tools/spline.rs
+++ b/examples/prefabs/src/tools/spline.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 
 use glam::{DVec2, DVec3};
-use insim::core::heading::Heading;
+use insim::core::heading::ObjectHeading;
 
 #[derive(Debug, Clone, Copy)]
 pub struct LutEntry {
@@ -122,17 +122,17 @@ pub fn sample_lut(lut: &[LutEntry], target_distance: f64) -> LutEntry {
     }
 }
 
-pub fn heading_to_forward(heading: Heading) -> DVec2 {
+pub fn heading_to_forward(heading: ObjectHeading) -> DVec2 {
     let radians = heading.to_radians();
     DVec2::new(-radians.sin(), radians.cos())
 }
 
-pub fn heading_from_vec2_or_fallback(vector: DVec2, fallback: Heading) -> Heading {
+pub fn heading_from_vec2_or_fallback(vector: DVec2, fallback: ObjectHeading) -> ObjectHeading {
     if vector.length_squared() <= f64::EPSILON {
         return fallback;
     }
     let tangent = vector.normalize();
-    Heading::from_radians((-tangent.x).atan2(tangent.y))
+    ObjectHeading::from_radians((-tangent.x).atan2(tangent.y))
 }
 
 pub fn normalize_or_fallback(vector: DVec3, fallback: DVec3) -> DVec3 {

--- a/examples/prefabs/src/tools/spline_distrib.rs
+++ b/examples/prefabs/src/tools/spline_distrib.rs
@@ -1,7 +1,7 @@
 use anyhow::{Result, anyhow};
 use glam::DVec3;
 use insim::{
-    core::{heading::Heading, object::ObjectCoordinate},
+    core::{heading::ObjectHeading, object::ObjectCoordinate},
     insim::ObjectInfo,
 };
 
@@ -28,7 +28,7 @@ pub fn build(
     let (lut, total_len) = spline::build_lut(&points, steps_per_segment, initial);
 
     let prototype = &selection[0];
-    let proto_heading = prototype.heading().unwrap_or(Heading::NORTH);
+    let proto_heading = prototype.heading().unwrap_or(ObjectHeading::NORTH);
 
     // generate spaced-out objects
     let num_objects = (total_len / spacing_meters).floor() as usize + 1;

--- a/examples/prefabs/src/ui/toolbox.rs
+++ b/examples/prefabs/src/ui/toolbox.rs
@@ -1,5 +1,5 @@
 use insim::{
-    core::heading::Heading,
+    core::heading::ObjectHeading,
     insim::{BtnStyle, ObjectInfo},
 };
 use insim_extra::{ui, ui::Component as _};
@@ -61,7 +61,7 @@ pub enum ToolboxMsg {
     GridLateralOffsetInput(String),
     BuildGrid,
     NudgeDistanceInput(String),
-    Nudge(Heading),
+    Nudge(ObjectHeading),
     JiggleSelection,
     ToggleTopDown,
     ToggleSideView,
@@ -386,7 +386,7 @@ fn nudge_panel(nudge_distance_metres: f64) -> ui::Node<ToolboxMsg> {
             .h(5.)
     };
 
-    let nudge_cell = |label: &'static str, heading: Heading| {
+    let nudge_cell = |label: &'static str, heading: ObjectHeading| {
         ui::clickable(
             label,
             BtnStyle::style_interactive(),
@@ -414,23 +414,23 @@ fn nudge_panel(nudge_distance_metres: f64) -> ui::Node<ToolboxMsg> {
                 .flex()
                 .flex_row()
                 .with_child(blank_cell())
-                .with_child(nudge_cell("N", Heading::NORTH))
+                .with_child(nudge_cell("N", ObjectHeading::NORTH))
                 .with_child(blank_cell()),
         )
         .with_child(
             ui::container()
                 .flex()
                 .flex_row()
-                .with_child(nudge_cell("W", Heading::WEST))
+                .with_child(nudge_cell("W", ObjectHeading::WEST))
                 .with_child(blank_cell())
-                .with_child(nudge_cell("E", Heading::EAST)),
+                .with_child(nudge_cell("E", ObjectHeading::EAST)),
         )
         .with_child(
             ui::container()
                 .flex()
                 .flex_row()
                 .with_child(blank_cell())
-                .with_child(nudge_cell("S", Heading::SOUTH))
+                .with_child(nudge_cell("S", ObjectHeading::SOUTH))
                 .with_child(blank_cell()),
         )
 }

--- a/insim/src/insim/contact.rs
+++ b/insim/src/insim/contact.rs
@@ -2,9 +2,13 @@
 // Do not name this file `con.rs`.
 use std::time::Duration;
 
-use insim_core::{Decode, DecodeContext, Encode, EncodeContext, heading::Heading, speed::Speed};
+use insim_core::{
+    Decode, DecodeContext, Encode, EncodeContext,
+    heading::Heading,
+    speed::{ClosingSpeed, SpeedU8},
+};
 
-use super::{CompCarInfo, obh::spclose_strip_high_bits};
+use super::CompCarInfo;
 use crate::identifiers::{PlayerId, RequestId};
 
 /// ConInfo direction scale: 128 units = 180°
@@ -40,7 +44,7 @@ pub struct ConInfo {
     pub gearsp: u8,
 
     /// Speed.
-    pub speed: Speed,
+    pub speed: SpeedU8,
 
     /// Direction of motion.
     pub direction: Heading,
@@ -80,7 +84,7 @@ impl Decode for ConInfo {
         let gearsp = ctx.decode::<u8>("gearsp")?;
         let gearsp = (gearsp >> 4) & 0x0F; // gearsp is only first 4 bits
 
-        let speed = Speed::from_meters_per_sec(ctx.decode::<u8>("speed")? as f32);
+        let speed = ctx.decode::<SpeedU8>("speed")?;
 
         let direction_raw = ctx.decode::<u8>("direction_raw")?;
         let direction = Heading::from_degrees((direction_raw as f64) * CONINFO_DEGREES_PER_UNIT);
@@ -175,7 +179,7 @@ impl Encode for ConInfo {
         let gearsp = self.gearsp << 4;
         ctx.encode("gearsp", &gearsp)?;
 
-        ctx.encode("speed", &(self.speed.to_meters_per_sec() as u8))?;
+        ctx.encode("speed", &self.speed)?;
 
         let direction_units = (self.direction.to_degrees() / CONINFO_DEGREES_PER_UNIT)
             .round()
@@ -207,7 +211,7 @@ pub struct Con {
     pub reqi: RequestId,
 
     /// Closing speed at impact.
-    pub spclose: Speed,
+    pub spclose: ClosingSpeed,
 
     /// Time since session start, in milliseconds (wraps periodically).
     #[cfg_attr(feature = "serde", serde(with = "crate::duration_serde"))]
@@ -225,8 +229,7 @@ impl Decode for Con {
     fn decode(ctx: &mut DecodeContext) -> Result<Self, insim_core::DecodeError> {
         let reqi = ctx.decode::<RequestId>("reqi")?;
         ctx.pad("sp0", 1)?;
-        let spclose = spclose_strip_high_bits(ctx.decode::<u16>("spclose")?);
-        let spclose = Speed::from_meters_per_sec(spclose as f32 / 10.0);
+        let spclose = ctx.decode::<ClosingSpeed>("spclose")?;
         ctx.pad("spw", 2)?;
         let time = ctx.decode_duration::<u32>("time")?;
 
@@ -247,10 +250,7 @@ impl Encode for Con {
     fn encode(&self, ctx: &mut EncodeContext) -> Result<(), insim_core::EncodeError> {
         ctx.encode("reqi", &self.reqi)?;
         ctx.pad("sp0", 1)?;
-        ctx.encode(
-            "spclose",
-            &spclose_strip_high_bits((self.spclose.to_meters_per_sec() * 10.0) as u16),
-        )?;
+        ctx.encode("spclose", &self.spclose)?;
         ctx.encode_duration::<u32>("time", self.time)?;
         ctx.encode("a", &self.a)?;
         ctx.encode("b", &self.b)?;

--- a/insim/src/insim/contact.rs
+++ b/insim/src/insim/contact.rs
@@ -22,8 +22,8 @@ pub struct ConInfo {
     /// Additional car state flags.
     pub info: CompCarInfo,
 
-    /// Front wheel steering angle (right positive).
-    pub steer: u8,
+    /// Front wheel steering angle in degrees (right positive, left negative).
+    pub steer: i8,
 
     /// Throttle input (0-15).
     pub thr: u8,
@@ -49,11 +49,11 @@ pub struct ConInfo {
     /// Car facing direction.
     pub heading: HeadingU8,
 
-    /// Longitudinal acceleration.
-    pub accelf: u8,
+    /// Longitudinal acceleration in m/s² (forward positive, braking negative).
+    pub accelf: i8,
 
-    /// Lateral acceleration.
-    pub accelr: u8,
+    /// Lateral acceleration in m/s² (rightward positive, leftward negative).
+    pub accelr: i8,
 
     /// X position.
     pub x: i16,
@@ -68,7 +68,7 @@ impl Decode for ConInfo {
         let info = ctx.decode::<CompCarInfo>("info")?;
         // pad 1 bytes
         ctx.pad("sp0", 1)?;
-        let steer = ctx.decode::<u8>("steer")?;
+        let steer = ctx.decode::<i8>("steer")?;
 
         let thrbrk = ctx.decode::<u8>("thrbrk")?;
         let thr: u8 = (thrbrk >> 4) & 0x0F; // upper 4 bits
@@ -86,8 +86,8 @@ impl Decode for ConInfo {
         let direction = ctx.decode::<HeadingU8>("direction")?;
         let heading = ctx.decode::<HeadingU8>("heading")?;
 
-        let accelf = ctx.decode::<u8>("accelf")?;
-        let accelr = ctx.decode::<u8>("accelr")?;
+        let accelf = ctx.decode::<i8>("accelf")?;
+        let accelr = ctx.decode::<i8>("accelr")?;
 
         let x = ctx.decode::<i16>("x")?;
         let y = ctx.decode::<i16>("y")?;

--- a/insim/src/insim/contact.rs
+++ b/insim/src/insim/contact.rs
@@ -4,15 +4,12 @@ use std::time::Duration;
 
 use insim_core::{
     Decode, DecodeContext, Encode, EncodeContext,
-    heading::Heading,
+    heading::HeadingU8,
     speed::{ClosingSpeed, SpeedU8},
 };
 
 use super::CompCarInfo;
 use crate::identifiers::{PlayerId, RequestId};
-
-/// ConInfo direction scale: 128 units = 180°
-const CONINFO_DEGREES_PER_UNIT: f64 = 180.0 / 128.0;
 
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -47,10 +44,10 @@ pub struct ConInfo {
     pub speed: SpeedU8,
 
     /// Direction of motion.
-    pub direction: Heading,
+    pub direction: HeadingU8,
 
     /// Car facing direction.
-    pub heading: Heading,
+    pub heading: HeadingU8,
 
     /// Longitudinal acceleration.
     pub accelf: u8,
@@ -86,11 +83,8 @@ impl Decode for ConInfo {
 
         let speed = ctx.decode::<SpeedU8>("speed")?;
 
-        let direction_raw = ctx.decode::<u8>("direction_raw")?;
-        let direction = Heading::from_degrees((direction_raw as f64) * CONINFO_DEGREES_PER_UNIT);
-
-        let heading_raw = ctx.decode::<u8>("heading_raw")?;
-        let heading = Heading::from_degrees((heading_raw as f64) * CONINFO_DEGREES_PER_UNIT);
+        let direction = ctx.decode::<HeadingU8>("direction")?;
+        let heading = ctx.decode::<HeadingU8>("heading")?;
 
         let accelf = ctx.decode::<u8>("accelf")?;
         let accelr = ctx.decode::<u8>("accelr")?;
@@ -181,15 +175,8 @@ impl Encode for ConInfo {
 
         ctx.encode("speed", &self.speed)?;
 
-        let direction_units = (self.direction.to_degrees() / CONINFO_DEGREES_PER_UNIT)
-            .round()
-            .clamp(0.0, 255.0) as u8;
-        ctx.encode("direction", &direction_units)?;
-
-        let heading_units = (self.heading.to_degrees() / CONINFO_DEGREES_PER_UNIT)
-            .round()
-            .clamp(0.0, 255.0) as u8;
-        ctx.encode("heading", &heading_units)?;
+        ctx.encode("direction", &self.direction)?;
+        ctx.encode("heading", &self.heading)?;
 
         ctx.encode("accelf", &self.accelf)?;
         ctx.encode("accelr", &self.accelr)?;

--- a/insim/src/insim/cpp.rs
+++ b/insim/src/insim/cpp.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use insim_core::{
-    Decode, DecodeContext, Encode, EncodeContext, coordinate::Coordinate, heading::Heading,
+    Decode, DecodeContext, Encode, EncodeContext, coordinate::Coordinate, heading::HeadingU16,
 };
 
 use super::{CameraView, StaFlags};
@@ -20,7 +20,7 @@ pub struct Cpp {
     pub pos: Coordinate,
 
     /// heading - 0 points along Y axis
-    pub h: Heading,
+    pub h: HeadingU16,
 
     /// Pitch
     pub p: u16,
@@ -52,9 +52,7 @@ impl Decode for Cpp {
         ctx.pad("zero", 1)?;
         let pos = ctx.decode::<Coordinate>("pos")?;
 
-        let h = Heading::from_degrees(
-            (ctx.decode::<u16>("h")? as f64) * super::mci::COMPCAR_DEGREES_PER_UNIT,
-        );
+        let h = ctx.decode::<HeadingU16>("h")?;
         let p = ctx.decode::<u16>("p")?;
         let r = ctx.decode::<u16>("r")?;
 
@@ -85,10 +83,7 @@ impl Encode for Cpp {
         ctx.encode("reqi", &self.reqi)?;
         ctx.pad("zero", 1)?;
         ctx.encode("pos", &self.pos)?;
-        let h = (self.h.to_degrees() / super::mci::COMPCAR_DEGREES_PER_UNIT)
-            .round()
-            .clamp(0.0, 65535.0) as u16;
-        ctx.encode("h", &h)?;
+        ctx.encode("h", &self.h)?;
         ctx.encode("p", &self.p)?;
         ctx.encode("r", &self.r)?;
         ctx.encode("viewplid", &self.viewplid)?;

--- a/insim/src/insim/jrr.rs
+++ b/insim/src/insim/jrr.rs
@@ -1,5 +1,5 @@
 use insim_core::{
-    Decode, DecodeContext, Encode, EncodeContext, heading::Heading, object::ObjectCoordinate,
+    Decode, DecodeContext, Encode, EncodeContext, heading::ObjectHeading, object::ObjectCoordinate,
 };
 
 use crate::identifiers::{ConnectionId, PlayerId, RequestId};
@@ -37,7 +37,7 @@ pub enum JrrStartPosition {
         /// Position
         xyz: ObjectCoordinate,
         /// Heading / Direction
-        heading: Heading,
+        heading: ObjectHeading,
     },
 }
 
@@ -56,7 +56,7 @@ impl Decode for JrrStartPosition {
         } else {
             Ok(Self::Custom {
                 xyz: ObjectCoordinate { x, y, z },
-                heading: Heading::from_objectinfo_wire(heading),
+                heading: ObjectHeading::from_raw(heading),
             })
         }
     }
@@ -72,7 +72,7 @@ impl Encode for JrrStartPosition {
                 ctx.encode("z", &xyz.z)?;
                 ctx.encode("flags", &0x80u8)?;
                 ctx.encode("index", &0u8)?;
-                ctx.encode("heading", &heading.to_objectinfo_wire())?;
+                ctx.encode("heading", &heading.to_raw())?;
             },
         };
         Ok(())

--- a/insim/src/insim/mci.rs
+++ b/insim/src/insim/mci.rs
@@ -1,6 +1,6 @@
 use bitflags::bitflags;
 use insim_core::{
-    Decode, DecodeContext, Encode, EncodeContext, angvel::AngVel, coordinate::Coordinate,
+    Decode, DecodeContext, Encode, EncodeContext, angvel::AngVelI16, coordinate::Coordinate,
     heading::HeadingU16, speed::SpeedU16,
 };
 
@@ -81,7 +81,7 @@ pub struct CompCar {
     pub heading: HeadingU16,
 
     /// Angular velocity of the car.
-    pub angvel: AngVel,
+    pub angvel: AngVelI16,
 }
 
 impl CompCar {
@@ -112,7 +112,7 @@ impl Decode for CompCar {
         let direction = ctx.decode::<HeadingU16>("direction")?;
         let heading = ctx.decode::<HeadingU16>("heading")?;
 
-        let angvel = AngVel::from_wire_i16(ctx.decode::<i16>("angvel")?);
+        let angvel = ctx.decode::<AngVelI16>("angvel")?;
         Ok(Self {
             node,
             lap,
@@ -142,7 +142,7 @@ impl Encode for CompCar {
         ctx.encode("direction", &self.direction)?;
         ctx.encode("heading", &self.heading)?;
 
-        ctx.encode("angvel", &self.angvel.to_wire_i16())?;
+        ctx.encode("angvel", &self.angvel)?;
         Ok(())
     }
 }

--- a/insim/src/insim/mci.rs
+++ b/insim/src/insim/mci.rs
@@ -1,13 +1,10 @@
 use bitflags::bitflags;
 use insim_core::{
     Decode, DecodeContext, Encode, EncodeContext, angvel::AngVel, coordinate::Coordinate,
-    heading::Heading, speed::SpeedU16,
+    heading::HeadingU16, speed::SpeedU16,
 };
 
 use crate::identifiers::{PlayerId, RequestId};
-
-/// CompCar direction scale: 32768 units = 180°
-pub(super) const COMPCAR_DEGREES_PER_UNIT: f64 = 180.0 / 32768.0;
 
 bitflags! {
     #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy, Default)]
@@ -78,10 +75,10 @@ pub struct CompCar {
     pub speed: SpeedU16,
 
     /// Direction of motion (heading of velocity).
-    pub direction: Heading,
+    pub direction: HeadingU16,
 
     /// Car facing direction.
-    pub heading: Heading,
+    pub heading: HeadingU16,
 
     /// Angular velocity of the car.
     pub angvel: AngVel,
@@ -112,11 +109,8 @@ impl Decode for CompCar {
 
         let speed = ctx.decode::<SpeedU16>("speed")?;
 
-        let direction_raw = ctx.decode::<u16>("direction")?;
-        let direction = Heading::from_degrees((direction_raw as f64) * COMPCAR_DEGREES_PER_UNIT);
-
-        let heading_raw = ctx.decode::<u16>("heading")?;
-        let heading = Heading::from_degrees((heading_raw as f64) * COMPCAR_DEGREES_PER_UNIT);
+        let direction = ctx.decode::<HeadingU16>("direction")?;
+        let heading = ctx.decode::<HeadingU16>("heading")?;
 
         let angvel = AngVel::from_wire_i16(ctx.decode::<i16>("angvel")?);
         Ok(Self {
@@ -145,15 +139,8 @@ impl Encode for CompCar {
         ctx.encode("xyz", &self.xyz)?;
         ctx.encode("speed", &self.speed)?;
 
-        let direction_units = (self.direction.to_degrees() / COMPCAR_DEGREES_PER_UNIT)
-            .round()
-            .clamp(0.0, 65535.0) as u16;
-        ctx.encode("direction", &direction_units)?;
-
-        let heading_units = (self.heading.to_degrees() / COMPCAR_DEGREES_PER_UNIT)
-            .round()
-            .clamp(0.0, 65535.0) as u16;
-        ctx.encode("heading", &heading_units)?;
+        ctx.encode("direction", &self.direction)?;
+        ctx.encode("heading", &self.heading)?;
 
         ctx.encode("angvel", &self.angvel.to_wire_i16())?;
         Ok(())

--- a/insim/src/insim/mci.rs
+++ b/insim/src/insim/mci.rs
@@ -1,7 +1,7 @@
 use bitflags::bitflags;
 use insim_core::{
     Decode, DecodeContext, Encode, EncodeContext, angvel::AngVel, coordinate::Coordinate,
-    heading::Heading, speed::Speed,
+    heading::Heading, speed::SpeedU16,
 };
 
 use crate::identifiers::{PlayerId, RequestId};
@@ -71,11 +71,11 @@ pub struct CompCar {
     /// Additional state flags.
     pub info: CompCarInfo,
 
-    /// World position in meters.
+    /// World position in metres.
     pub xyz: Coordinate,
 
     /// Speed.
-    pub speed: Speed,
+    pub speed: SpeedU16,
 
     /// Direction of motion (heading of velocity).
     pub direction: Heading,
@@ -110,8 +110,7 @@ impl Decode for CompCar {
 
         let xyz = ctx.decode::<Coordinate>("xyz")?;
 
-        let speed = (ctx.decode::<u16>("speed")? as f32) / 327.68;
-        let speed = Speed::from_meters_per_sec(speed);
+        let speed = ctx.decode::<SpeedU16>("speed")?;
 
         let direction_raw = ctx.decode::<u16>("direction")?;
         let direction = Heading::from_degrees((direction_raw as f64) * COMPCAR_DEGREES_PER_UNIT);
@@ -144,8 +143,7 @@ impl Encode for CompCar {
         ctx.encode("info", &self.info)?;
         ctx.pad("sp3", 1)?;
         ctx.encode("xyz", &self.xyz)?;
-        let speed = (self.speed.to_meters_per_sec() * 327.68) as u16;
-        ctx.encode("speed", &speed)?;
+        ctx.encode("speed", &self.speed)?;
 
         let direction_units = (self.direction.to_degrees() / COMPCAR_DEGREES_PER_UNIT)
             .round()

--- a/insim/src/insim/obh.rs
+++ b/insim/src/insim/obh.rs
@@ -1,16 +1,16 @@
 use std::time::Duration;
 
 use bitflags::bitflags;
-use insim_core::{Decode, DecodeContext, Encode, EncodeContext, heading::Heading, speed::Speed};
+use insim_core::{
+    Decode, DecodeContext, Encode, EncodeContext,
+    heading::Heading,
+    speed::{ClosingSpeed, SpeedU8},
+};
 
 use crate::identifiers::{PlayerId, RequestId};
 
 /// CarContact direction scale: 128 units = 180°
 const CARCONTACT_DEGREES_PER_UNIT: f64 = 180.0 / 128.0;
-
-pub(crate) fn spclose_strip_high_bits(val: u16) -> u16 {
-    val & !61440
-}
 
 bitflags! {
     #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy, Default)]
@@ -51,7 +51,7 @@ pub struct CarContact {
     pub heading: Heading,
 
     /// Speed.
-    pub speed: Speed,
+    pub speed: SpeedU8,
 
     /// Z position.
     pub z: u8,
@@ -71,7 +71,7 @@ impl Decode for CarContact {
         let heading_raw = ctx.decode::<u8>("heading_raw")?;
         let heading = Heading::from_degrees((heading_raw as f64) * CARCONTACT_DEGREES_PER_UNIT);
 
-        let speed = Speed::from_meters_per_sec(ctx.decode::<u8>("speed")? as f32);
+        let speed = ctx.decode::<SpeedU8>("speed")?;
         let z = ctx.decode::<u8>("z")?;
         let x = ctx.decode::<i16>("x")?;
         let y = ctx.decode::<i16>("y")?;
@@ -98,7 +98,7 @@ impl Encode for CarContact {
             .clamp(0.0, 255.0) as u8;
         ctx.encode("heading", &heading_units)?;
 
-        ctx.encode("speed", &(self.speed.to_meters_per_sec() as u8))?;
+        ctx.encode("speed", &self.speed)?;
         ctx.encode("z", &self.z)?;
         ctx.encode("x", &self.x)?;
         ctx.encode("y", &self.y)?;
@@ -120,7 +120,7 @@ pub struct Obh {
     pub plid: PlayerId,
 
     /// Closing speed at impact.
-    pub spclose: Speed,
+    pub spclose: ClosingSpeed,
 
     /// Time since session start, in milliseconds (wraps periodically).
     #[cfg_attr(feature = "serde", serde(with = "crate::duration_serde"))]
@@ -150,9 +150,8 @@ impl Decode for Obh {
     fn decode(ctx: &mut DecodeContext) -> Result<Self, insim_core::DecodeError> {
         let reqi = ctx.decode::<RequestId>("reqi")?;
         let plid = ctx.decode::<PlayerId>("plid")?;
-        // automatically strip off the first 4 bits as they're reserved
-        let spclose = spclose_strip_high_bits(ctx.decode::<u16>("spclose")?);
-        let spclose = Speed::from_meters_per_sec(spclose as f32 / 10.0);
+        // ClosingSpeed masks off the reserved top 4 bits on decode.
+        let spclose = ctx.decode::<ClosingSpeed>("spclose")?;
         ctx.pad("spw", 2)?;
 
         let time = ctx.decode_duration::<u32>("time")?;
@@ -183,9 +182,7 @@ impl Encode for Obh {
     fn encode(&self, ctx: &mut EncodeContext) -> Result<(), insim_core::EncodeError> {
         ctx.encode("reqi", &self.reqi)?;
         ctx.encode("plid", &self.plid)?;
-        // automatically strip off the first 4 bits as they're reserved
-        let spclose = spclose_strip_high_bits((self.spclose.into_inner() * 10.0) as u16);
-        ctx.encode("spclose", &spclose)?;
+        ctx.encode("spclose", &self.spclose)?;
         ctx.pad("spw", 2)?;
         ctx.encode_duration::<u32>("time", self.time)?;
         ctx.encode("c", &self.c)?;
@@ -239,15 +236,8 @@ mod tests {
                 assert_eq!(obh.reqi, RequestId(0));
                 assert_eq!(obh.plid, PlayerId(3));
                 assert_eq!(obh.time, Duration::from_millis(4970));
-                assert_eq!(obh.spclose.into_inner(), 23.0 / 10.0);
+                assert_eq!(obh.spclose.to_metres_per_sec(), 23.0 / 10.0);
             }
         );
-    }
-
-    #[test]
-    fn ensure_high_bits_stripped() {
-        assert_eq!(spclose_strip_high_bits(61441), 1);
-
-        assert_eq!(spclose_strip_high_bits(63495,), 2055);
     }
 }

--- a/insim/src/insim/obh.rs
+++ b/insim/src/insim/obh.rs
@@ -3,14 +3,11 @@ use std::time::Duration;
 use bitflags::bitflags;
 use insim_core::{
     Decode, DecodeContext, Encode, EncodeContext,
-    heading::Heading,
+    heading::HeadingU8,
     speed::{ClosingSpeed, SpeedU8},
 };
 
 use crate::identifiers::{PlayerId, RequestId};
-
-/// CarContact direction scale: 128 units = 180°
-const CARCONTACT_DEGREES_PER_UNIT: f64 = 180.0 / 128.0;
 
 bitflags! {
     #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy, Default)]
@@ -45,10 +42,10 @@ impl_bitflags_from_to_bytes!(ObhFlags, u8);
 /// Contact details used by collision reports.
 pub struct CarContact {
     /// Direction of motion.
-    pub direction: Heading,
+    pub direction: HeadingU8,
 
     /// Car facing direction.
-    pub heading: Heading,
+    pub heading: HeadingU8,
 
     /// Speed.
     pub speed: SpeedU8,
@@ -65,11 +62,8 @@ pub struct CarContact {
 
 impl Decode for CarContact {
     fn decode(ctx: &mut DecodeContext) -> Result<Self, insim_core::DecodeError> {
-        let direction_raw = ctx.decode::<u8>("direction_raw")?;
-        let direction = Heading::from_degrees((direction_raw as f64) * CARCONTACT_DEGREES_PER_UNIT);
-
-        let heading_raw = ctx.decode::<u8>("heading_raw")?;
-        let heading = Heading::from_degrees((heading_raw as f64) * CARCONTACT_DEGREES_PER_UNIT);
+        let direction = ctx.decode::<HeadingU8>("direction")?;
+        let heading = ctx.decode::<HeadingU8>("heading")?;
 
         let speed = ctx.decode::<SpeedU8>("speed")?;
         let z = ctx.decode::<u8>("z")?;
@@ -88,15 +82,8 @@ impl Decode for CarContact {
 
 impl Encode for CarContact {
     fn encode(&self, ctx: &mut EncodeContext) -> Result<(), insim_core::EncodeError> {
-        let direction_units = (self.direction.to_degrees() / CARCONTACT_DEGREES_PER_UNIT)
-            .round()
-            .clamp(0.0, 255.0) as u8;
-        ctx.encode("direction", &direction_units)?;
-
-        let heading_units = (self.heading.to_degrees() / CARCONTACT_DEGREES_PER_UNIT)
-            .round()
-            .clamp(0.0, 255.0) as u8;
-        ctx.encode("heading", &heading_units)?;
+        ctx.encode("direction", &self.direction)?;
+        ctx.encode("heading", &self.heading)?;
 
         ctx.encode("speed", &self.speed)?;
         ctx.encode("z", &self.z)?;

--- a/insim/src/insim/uco.rs
+++ b/insim/src/insim/uco.rs
@@ -112,7 +112,7 @@ mod test {
                 ));
                 assert!(matches!(parsed.ucoaction, UcoAction::CircleLeave));
                 assert_eq!(parsed.time, Duration::from_millis(151560));
-                assert_eq!(parsed.c.speed.to_meters_per_sec() as u8, 8);
+                assert_eq!(parsed.c.speed.to_raw(), 8);
                 assert_eq!(parsed.c.x, -314);
                 assert_eq!(parsed.c.y, -1496);
                 assert_eq!(parsed.c.z, 10);

--- a/insim_core/src/angvel.rs
+++ b/insim_core/src/angvel.rs
@@ -12,8 +12,8 @@ use std::fmt;
 ///
 /// - `from_wire_i16` / `to_wire_i16` use the LFS scaling (16384 = 360°/s).
 /// - Positive values indicate clockwise rotation when viewed from above.
-/// - Stored as `f32` radians/sec for consistency with [`Heading`](crate::heading::Heading)
-///   and [`SpeedF32`](crate::speed::SpeedF32).
+/// - Stored as `f32` radians/sec for consistency with
+///   [`HeadingU16`](crate::heading::HeadingU16) and [`SpeedF32`](crate::speed::SpeedF32).
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]

--- a/insim_core/src/angvel.rs
+++ b/insim_core/src/angvel.rs
@@ -43,6 +43,11 @@ impl AngVelI16 {
         self.0
     }
 
+    /// Consumes `self`, returning the raw inner value (same as [`to_raw`](Self::to_raw)).
+    pub const fn into_inner(self) -> i16 {
+        self.0
+    }
+
     /// Construct from degrees per second (rounded to the nearest wire unit).
     pub fn from_degrees_per_sec(value: f32) -> Self {
         let units = (value / 360.0 * Self::UNITS_PER_TURN_PER_SEC).round();

--- a/insim_core/src/angvel.rs
+++ b/insim_core/src/angvel.rs
@@ -13,7 +13,7 @@ use std::fmt;
 /// - `from_wire_i16` / `to_wire_i16` use the LFS scaling (16384 = 360°/s).
 /// - Positive values indicate clockwise rotation when viewed from above.
 /// - Stored as `f32` radians/sec for consistency with [`Heading`](crate::heading::Heading)
-///   and [`Speed`](crate::speed::Speed).
+///   and [`SpeedF32`](crate::speed::SpeedF32).
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]

--- a/insim_core/src/angvel.rs
+++ b/insim_core/src/angvel.rs
@@ -1,122 +1,107 @@
-//! Angular Velocity
+//! Angular velocity wire type.
 //!
-//! AngVel represents the rate of change of heading (angular velocity), normalized internally
-//! to radians per second. The LFS protocol encodes this as a signed i16 where:
-//! - 16384 = 360 deg/s (clockwise when viewed from above)
-//! - 8192 = 180 deg/s (clockwise when viewed from above)
-//! - Negative values indicate anticlockwise rotation
+//! LFS (in `Mci`'s `CompCar`) encodes angular velocity as a signed `i16` where
+//! 16384 = 360°/s. Rather than decode to a lossy floating-point value and convert
+//! back (which is not idempotent on the wire), [`AngVelI16`] stores the **raw
+//! integer** and exposes degree/radian accessors on demand. Decoding then encoding
+//! reproduces the original `i16` exactly.
+//!
+//! - 16384 = 360°/s, 8192 = 180°/s.
+//! - Positive values are clockwise viewed from above; negative anticlockwise.
+//!
+//! Note: OutSim transmits angular velocity as a [`Vector`](crate::vector::Vector)
+//! of real `f32`s, not this fixed-point form.
 
 use std::fmt;
 
-/// Angular velocity stored as radians per second (f32).
+use crate::{Decode, Encode};
+
+/// Angular velocity as transmitted in `CompCar` (MCI): a signed `i16` where
+/// 16384 = 360°/s.
 ///
-/// - `from_wire_i16` / `to_wire_i16` use the LFS scaling (16384 = 360°/s).
-/// - Positive values indicate clockwise rotation when viewed from above.
-/// - Stored as `f32` radians/sec for consistency with
-///   [`HeadingU16`](crate::heading::HeadingU16) and [`SpeedF32`](crate::speed::SpeedF32).
-#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
+/// Stores the raw wire value; conversions to degrees/radians per second are
+/// accessors. Decoding then encoding reproduces the original `i16` exactly.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-pub struct AngVel {
-    radians_per_sec: f32,
-}
+pub struct AngVelI16(i16);
 
-impl AngVel {
-    /// AngVel of zero (no rotation).
-    pub const ZERO: Self = Self::from_radians_per_sec(0.0);
+impl AngVelI16 {
+    /// Zero angular velocity.
+    pub const ZERO: Self = Self(0);
 
-    /// LFS protocol scale: 16384 = 360 deg/s
-    const SCALE: f32 = 360.0 / 16384.0;
+    /// Raw wire units per 360°/s.
+    const UNITS_PER_TURN_PER_SEC: f32 = 16384.0;
 
-    /// Consumes AngVel, returning the inner radian/sec value.
-    pub fn into_inner(self) -> f32 {
-        self.radians_per_sec
+    /// Construct from the raw wire value (lossless).
+    pub const fn from_raw(raw: i16) -> Self {
+        Self(raw)
     }
 
-    /// Create AngVel from radians per second.
-    pub const fn from_radians_per_sec(value: f32) -> Self {
-        Self {
-            radians_per_sec: value,
-        }
+    /// The raw wire value (lossless).
+    pub const fn to_raw(self) -> i16 {
+        self.0
     }
 
-    /// Get the angular velocity in radians per second.
-    pub const fn to_radians_per_sec(&self) -> f32 {
-        self.radians_per_sec
+    /// Construct from degrees per second (rounded to the nearest wire unit).
+    pub fn from_degrees_per_sec(value: f32) -> Self {
+        let units = (value / 360.0 * Self::UNITS_PER_TURN_PER_SEC).round();
+        Self(units.clamp(i16::MIN as f32, i16::MAX as f32) as i16)
     }
 
-    /// Create AngVel from degrees per second.
-    pub const fn from_degrees_per_sec(value: f32) -> Self {
-        Self {
-            radians_per_sec: value * std::f32::consts::PI / 180.0,
-        }
+    /// Angular velocity in degrees per second.
+    pub fn to_degrees_per_sec(self) -> f32 {
+        self.0 as f32 / Self::UNITS_PER_TURN_PER_SEC * 360.0
     }
 
-    /// Get the angular velocity in degrees per second.
-    pub fn to_degrees_per_sec(&self) -> f32 {
-        self.radians_per_sec * 180.0 / std::f32::consts::PI
+    /// Construct from radians per second.
+    pub fn from_radians_per_sec(value: f32) -> Self {
+        Self::from_degrees_per_sec(value.to_degrees())
     }
 
-    /// Create AngVel from LFS protocol raw i16 value (16384 = 360 deg/s).
-    pub fn from_wire_i16(raw: i16) -> Self {
-        let degrees_per_sec = raw as f32 * Self::SCALE;
-        Self::from_degrees_per_sec(degrees_per_sec)
+    /// Angular velocity in radians per second.
+    pub fn to_radians_per_sec(self) -> f32 {
+        self.to_degrees_per_sec().to_radians()
     }
 
-    /// Get the LFS protocol raw i16 value (16384 = 360 deg/s).
-    pub fn to_wire_i16(&self) -> i16 {
-        (self.to_degrees_per_sec() / Self::SCALE).round() as i16
+    /// Whether this represents clockwise rotation (viewed from above), i.e. the
+    /// raw value is positive.
+    pub const fn clockwise(self) -> bool {
+        self.0 > 0
     }
 
-    /// Check if this angular velocity represents clockwise rotation (when viewed from above).
-    ///
-    /// Returns true if the angular velocity is positive (clockwise), false otherwise.
-    ///
-    /// # Examples
-    /// ```
-    /// use insim_core::angvel::AngVel;
-    /// let clockwise = AngVel::from_degrees_per_sec(90.0);
-    /// assert!(clockwise.clockwise());
-    ///
-    /// let anticlockwise = AngVel::from_degrees_per_sec(-90.0);
-    /// assert!(!anticlockwise.clockwise());
-    /// ```
-    pub fn clockwise(&self) -> bool {
-        self.radians_per_sec > 0.0
+    /// Whether this represents anticlockwise rotation (viewed from above), i.e.
+    /// the raw value is negative.
+    pub const fn anticlockwise(self) -> bool {
+        self.0 < 0
     }
 
-    /// Check if this angular velocity represents anticlockwise rotation (when viewed from above).
-    ///
-    /// Returns true if the angular velocity is negative (anticlockwise), false otherwise.
-    ///
-    /// # Examples
-    /// ```
-    /// use insim_core::angvel::AngVel;
-    /// let anticlockwise = AngVel::from_degrees_per_sec(-90.0);
-    /// assert!(anticlockwise.anticlockwise());
-    ///
-    /// let clockwise = AngVel::from_degrees_per_sec(90.0);
-    /// assert!(!clockwise.anticlockwise());
-    /// ```
-    pub fn anticlockwise(&self) -> bool {
-        self.radians_per_sec < 0.0
+    /// Whether this is exactly zero.
+    pub const fn is_zero(self) -> bool {
+        self.0 == 0
     }
 }
 
-impl Default for AngVel {
-    fn default() -> Self {
-        Self::ZERO
-    }
-}
-
-impl fmt::Display for AngVel {
+impl fmt::Display for AngVelI16 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{:.2} rad/s ({:.2}°/s)",
-            self.radians_per_sec,
+            self.to_radians_per_sec(),
             self.to_degrees_per_sec()
         )
+    }
+}
+
+impl Decode for AngVelI16 {
+    fn decode(ctx: &mut crate::DecodeContext) -> Result<Self, crate::DecodeError> {
+        Ok(Self(ctx.decode::<i16>("angvel")?))
+    }
+}
+
+impl Encode for AngVelI16 {
+    fn encode(&self, ctx: &mut crate::EncodeContext) -> Result<(), crate::EncodeError> {
+        ctx.encode("angvel", &self.0)
     }
 }
 
@@ -125,151 +110,41 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_zero() {
-        assert_eq!(AngVel::ZERO.to_radians_per_sec(), 0.0);
-        assert_eq!(AngVel::ZERO.to_degrees_per_sec(), 0.0);
+    fn test_raw_roundtrip_exact() {
+        for raw in [i16::MIN, -8192, -1, 0, 1, 8192, 16384, i16::MAX] {
+            assert_eq!(AngVelI16::from_raw(raw).to_raw(), raw);
+        }
     }
 
     #[test]
-    fn test_from_radians_per_sec() {
-        let av = AngVel::from_radians_per_sec(std::f32::consts::PI);
-        assert!((av.to_radians_per_sec() - std::f32::consts::PI).abs() < 0.0001);
+    fn test_degrees_per_sec() {
+        // 16384 = 360°/s, 8192 = 180°/s
+        assert_eq!(AngVelI16::from_raw(16384).to_degrees_per_sec(), 360.0);
+        assert_eq!(AngVelI16::from_raw(8192).to_degrees_per_sec(), 180.0);
+        assert_eq!(AngVelI16::from_raw(-8192).to_degrees_per_sec(), -180.0);
+
+        assert_eq!(AngVelI16::from_degrees_per_sec(360.0).to_raw(), 16384);
+        assert_eq!(AngVelI16::from_degrees_per_sec(180.0).to_raw(), 8192);
     }
 
     #[test]
-    fn test_from_degrees_per_sec() {
-        let av = AngVel::from_degrees_per_sec(180.0);
-        assert!((av.to_degrees_per_sec() - 180.0).abs() < 0.0001);
-    }
-
-    #[test]
-    fn test_roundtrip_radians_per_sec() {
-        let original = 2.5;
-        let av = AngVel::from_radians_per_sec(original);
-        assert!((av.to_radians_per_sec() - original).abs() < 0.0001);
-    }
-
-    #[test]
-    fn test_roundtrip_degrees_per_sec() {
-        let original = 45.0;
-        let av = AngVel::from_degrees_per_sec(original);
-        assert!((av.to_degrees_per_sec() - original).abs() < 0.0001);
-    }
-
-    #[test]
-    fn test_conversion_radians_to_degrees() {
-        // π rad/s = 180 deg/s
-        let av = AngVel::from_radians_per_sec(std::f32::consts::PI);
-        assert!((av.to_degrees_per_sec() - 180.0).abs() < 0.0001);
-    }
-
-    #[test]
-    fn test_conversion_degrees_to_radians() {
-        // 180 deg/s = π rad/s
-        let av = AngVel::from_degrees_per_sec(180.0);
-        assert!((av.to_radians_per_sec() - std::f32::consts::PI).abs() < 0.0001);
-    }
-
-    #[test]
-    fn test_lfs_raw_360_degrees() {
-        // 16384 = 360 deg/s
-        let av = AngVel::from_wire_i16(16384);
-        assert!((av.to_degrees_per_sec() - 360.0).abs() < 0.0001);
-    }
-
-    #[test]
-    fn test_lfs_raw_180_degrees() {
-        // 8192 = 180 deg/s
-        let av = AngVel::from_wire_i16(8192);
-        assert!((av.to_degrees_per_sec() - 180.0).abs() < 0.0001);
-    }
-
-    #[test]
-    fn test_lfs_raw_negative() {
-        // Negative values indicate anticlockwise rotation
-        let av = AngVel::from_wire_i16(-8192);
-        assert!((av.to_degrees_per_sec() - (-180.0)).abs() < 0.0001);
-    }
-
-    #[test]
-    fn test_to_lfs_i16_roundtrip() {
-        let original = 12345i16;
-        let av = AngVel::from_wire_i16(original);
-        let roundtrip = av.to_wire_i16();
-        assert_eq!(roundtrip, original);
-    }
-
-    #[test]
-    fn test_to_lfs_i16_360_degrees() {
-        let av = AngVel::from_degrees_per_sec(360.0);
-        assert_eq!(av.to_wire_i16(), 16384);
-    }
-
-    #[test]
-    fn test_to_lfs_i16_180_degrees() {
-        let av = AngVel::from_degrees_per_sec(180.0);
-        assert_eq!(av.to_wire_i16(), 8192);
-    }
-
-    #[test]
-    fn test_into_inner() {
-        let original = 1.5;
-        let av = AngVel::from_radians_per_sec(original);
-        assert_eq!(av.into_inner(), original);
-    }
-
-    #[test]
-    fn test_default() {
-        let av = AngVel::default();
-        assert_eq!(av.to_radians_per_sec(), 0.0);
-    }
-
-    #[test]
-    fn test_display() {
-        let av = AngVel::from_degrees_per_sec(90.0);
-        let display_str = format!("{}", av);
-        // Should contain both rad/s and deg/s representations
-        assert!(display_str.contains("rad/s"));
-        assert!(display_str.contains("°/s"));
-    }
-
-    #[test]
-    fn test_partial_eq() {
-        let av1 = AngVel::from_degrees_per_sec(45.0);
-        let av2 = AngVel::from_degrees_per_sec(45.0);
-        let av3 = AngVel::from_degrees_per_sec(90.0);
-
-        assert_eq!(av1, av2);
-        assert_ne!(av1, av3);
-    }
-
-    #[test]
-    fn test_partial_ord() {
-        let av1 = AngVel::from_degrees_per_sec(45.0);
-        let av2 = AngVel::from_degrees_per_sec(90.0);
-
-        assert!(av1 < av2);
-        assert!(av2 > av1);
+    fn test_radians_per_sec() {
+        let av = AngVelI16::from_raw(8192);
+        assert!((av.to_radians_per_sec() - std::f32::consts::PI).abs() < 1e-4);
     }
 
     #[test]
     fn test_clockwise() {
-        let clockwise = AngVel::from_degrees_per_sec(90.0);
-        assert!(clockwise.clockwise());
-        assert!(!clockwise.anticlockwise());
+        assert!(AngVelI16::from_raw(90).clockwise());
+        assert!(!AngVelI16::from_raw(90).anticlockwise());
+        assert!(AngVelI16::from_raw(-90).anticlockwise());
+        assert!(!AngVelI16::ZERO.clockwise());
+        assert!(!AngVelI16::ZERO.anticlockwise());
     }
 
     #[test]
-    fn test_anticlockwise() {
-        let anticlockwise = AngVel::from_degrees_per_sec(-90.0);
-        assert!(anticlockwise.anticlockwise());
-        assert!(!anticlockwise.clockwise());
-    }
-
-    #[test]
-    fn test_clockwise_zero() {
-        let zero = AngVel::ZERO;
-        assert!(!zero.clockwise());
-        assert!(!zero.anticlockwise());
+    fn test_default_and_zero() {
+        assert!(AngVelI16::default().is_zero());
+        assert_eq!(AngVelI16::default(), AngVelI16::ZERO);
     }
 }

--- a/insim_core/src/coordinate.rs
+++ b/insim_core/src/coordinate.rs
@@ -24,27 +24,32 @@ impl Coordinate {
     const SCALE: i32 = 65536;
 
     /// X (in metres)
+    #[doc(alias = "x_meters")]
     pub fn x_metres(&self) -> f32 {
         self.x as f32 / Self::SCALE as f32
     }
 
     /// Y (in metres)
+    #[doc(alias = "y_meters")]
     pub fn y_metres(&self) -> f32 {
         self.y as f32 / Self::SCALE as f32
     }
 
     /// Z (in metres)
+    #[doc(alias = "z_meters")]
     pub fn z_metres(&self) -> f32 {
         self.z as f32 / Self::SCALE as f32
     }
 
     /// X, Y, Z (in metres)
+    #[doc(alias = "xyz_meters")]
     pub fn xyz_metres(&self) -> (f32, f32, f32) {
         (self.x_metres(), self.y_metres(), self.z_metres())
     }
 
     /// Convert to glam Vec3, where xyz are in metres
     #[cfg(feature = "glam")]
+    #[doc(alias = "to_vec3_meters")]
     pub fn to_vec3_metres(self) -> glam::Vec3 {
         glam::Vec3::new(
             self.x as f32 / Self::SCALE as f32,
@@ -55,6 +60,7 @@ impl Coordinate {
 
     /// Convert from glam Vec3, where the Vec3 is in metres
     #[cfg(feature = "glam")]
+    #[doc(alias = "from_dvec3_meters")]
     pub fn from_dvec3_metres(other: glam::DVec3) -> Self {
         Self {
             x: (other.x * Self::SCALE as f64).round() as i32,
@@ -65,6 +71,7 @@ impl Coordinate {
 
     /// Convert to glam Vec3, where xyz are in metres
     #[cfg(feature = "glam")]
+    #[doc(alias = "to_dvec3_meters")]
     pub fn to_dvec3_metres(self) -> glam::DVec3 {
         glam::DVec3::new(
             self.x as f64 / Self::SCALE as f64,
@@ -75,6 +82,7 @@ impl Coordinate {
 
     /// Convert from glam Vec3, where the Vec3 is in metres
     #[cfg(feature = "glam")]
+    #[doc(alias = "from_vec3_meters")]
     pub fn from_vec3_metres(other: glam::Vec3) -> Self {
         Self {
             x: (other.x * Self::SCALE as f32).round() as i32,

--- a/insim_core/src/coordinate.rs
+++ b/insim_core/src/coordinate.rs
@@ -57,9 +57,9 @@ impl Coordinate {
     #[cfg(feature = "glam")]
     pub fn from_dvec3_metres(other: glam::DVec3) -> Self {
         Self {
-            x: other.x as i32 * Self::SCALE,
-            y: other.y as i32 * Self::SCALE,
-            z: other.z as i32 * Self::SCALE,
+            x: (other.x * Self::SCALE as f64).round() as i32,
+            y: (other.y * Self::SCALE as f64).round() as i32,
+            z: (other.z * Self::SCALE as f64).round() as i32,
         }
     }
 
@@ -77,19 +77,19 @@ impl Coordinate {
     #[cfg(feature = "glam")]
     pub fn from_vec3_metres(other: glam::Vec3) -> Self {
         Self {
-            x: other.x as i32 * Self::SCALE,
-            y: other.y as i32 * Self::SCALE,
-            z: other.z as i32 * Self::SCALE,
+            x: (other.x * Self::SCALE as f32).round() as i32,
+            y: (other.y * Self::SCALE as f32).round() as i32,
+            z: (other.z * Self::SCALE as f32).round() as i32,
         }
     }
 
-    /// Convert to glam Vec3, where xyz are in the internal representation of 63336 = 1m
+    /// Convert to glam Vec3, where xyz are in the internal representation of 65536 = 1m
     #[cfg(feature = "glam")]
     pub fn to_vec3(self) -> glam::Vec3 {
         glam::Vec3::new(self.x as f32, self.y as f32, self.z as f32)
     }
 
-    /// Convert from glam Vec3, where the Vec3 represents 63336 = 1m
+    /// Convert from glam Vec3, where the Vec3 represents 65536 = 1m
     #[cfg(feature = "glam")]
     pub fn from_vec3(other: glam::Vec3) -> Self {
         Self {
@@ -99,13 +99,13 @@ impl Coordinate {
         }
     }
 
-    /// Convert to glam IVec3, where xyz are in the internal representation of 63336 = 1m
+    /// Convert to glam IVec3, where xyz are in the internal representation of 65536 = 1m
     #[cfg(feature = "glam")]
     pub fn to_ivec3(self) -> glam::IVec3 {
         glam::IVec3::new(self.x, self.y, self.z)
     }
 
-    /// Convert from glam IVec3, where the Vec3 represents 63336 = 1m
+    /// Convert from glam IVec3, where the Vec3 represents 65536 = 1m
     #[cfg(feature = "glam")]
     pub fn from_ivec3(other: glam::IVec3) -> Self {
         Self {
@@ -131,5 +131,75 @@ impl Encode for Coordinate {
         ctx.encode("x", &self.x)?;
         ctx.encode("y", &self.y)?;
         ctx.encode("z", &self.z)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Decode, Encode};
+
+    /// Decode -> encode must reproduce the bytes exactly, for every component.
+    #[test]
+    fn test_roundtrip_bytes_exact() {
+        for coord in [
+            Coordinate { x: 0, y: 0, z: 0 },
+            Coordinate {
+                x: i32::MIN,
+                y: i32::MAX,
+                z: -1,
+            },
+            Coordinate {
+                x: 65536,
+                y: -98304,
+                z: 1,
+            },
+        ] {
+            let bytes = coord.to_bytes().unwrap();
+            let decoded = Coordinate::decode_slice(&bytes).unwrap();
+            assert_eq!(coord, decoded, "raw value must survive a byte round-trip");
+        }
+    }
+
+    /// Re-encoding decoded bytes must yield the identical byte string (idempotent).
+    #[test]
+    fn test_roundtrip_idempotent() {
+        let original: &[u8] = &[
+            0x6b, 0x70, 0xfc, 0x00, // x
+            0x8e, 0xdc, 0x47, 0x00, // y
+            0x10, 0x27, 0x00, 0x00, // z
+        ];
+        let decoded = Coordinate::decode_slice(original).unwrap();
+        let reencoded = decoded.to_bytes().unwrap();
+        assert_eq!(&reencoded[..], original);
+    }
+
+    #[cfg(feature = "glam")]
+    #[test]
+    fn test_from_dvec3_metres_does_not_truncate() {
+        // 1.5 m must scale to 1.5 * 65536 = 98304, not 65536 (the old truncating bug).
+        let c = Coordinate::from_dvec3_metres(glam::DVec3::new(1.5, -2.25, 0.5));
+        assert_eq!(c.x, 98304);
+        assert_eq!(c.y, -147456);
+        assert_eq!(c.z, 32768);
+    }
+
+    #[cfg(feature = "glam")]
+    #[test]
+    fn test_from_vec3_metres_does_not_truncate() {
+        let c = Coordinate::from_vec3_metres(glam::Vec3::new(1.5, -2.25, 0.5));
+        assert_eq!(c.x, 98304);
+        assert_eq!(c.y, -147456);
+        assert_eq!(c.z, 32768);
+    }
+
+    #[cfg(feature = "glam")]
+    #[test]
+    fn test_metres_roundtrip_dvec3() {
+        // Values chosen to be exactly representable so the round-trip is lossless.
+        let original = glam::DVec3::new(12.5, -340.25, 7.125);
+        let c = Coordinate::from_dvec3_metres(original);
+        let back = c.to_dvec3_metres();
+        assert_eq!(back, original);
     }
 }

--- a/insim_core/src/decode/mod.rs
+++ b/insim_core/src/decode/mod.rs
@@ -62,6 +62,14 @@ impl Decode for u8 {
     }
 }
 
+impl Decode for i8 {
+    const PRIMITIVE: bool = true;
+
+    fn decode(ctx: &mut DecodeContext) -> Result<Self, DecodeError> {
+        Ok(ctx.buf.get_i8())
+    }
+}
+
 impl Decode for u16 {
     const PRIMITIVE: bool = true;
 

--- a/insim_core/src/encode/mod.rs
+++ b/insim_core/src/encode/mod.rs
@@ -61,6 +61,16 @@ impl Encode for u8 {
     }
 }
 
+impl Encode for i8 {
+    const PRIMITIVE: bool = true;
+
+    fn encode(&self, ctx: &mut EncodeContext) -> Result<(), EncodeError> {
+        ctx.buf.put_i8(*self);
+
+        Ok(())
+    }
+}
+
 impl Encode for u16 {
     const PRIMITIVE: bool = true;
 

--- a/insim_core/src/heading.rs
+++ b/insim_core/src/heading.rs
@@ -1,363 +1,248 @@
-//! Heading
+//! Heading / direction wire types.
+//!
+//! LFS encodes headings as fixed-point integers at different resolutions and, in
+//! one case, a different zero-point. Rather than decode to a lossy floating-point
+//! angle and convert back (which is not idempotent on the wire), each wire encoding
+//! has its own newtype that stores the **raw integer** and exposes degree/radian
+//! accessors on demand. Decoding then re-encoding reproduces the original bytes
+//! exactly.
+//!
+//! All types share the same orientation convention as LFS: angles increase
+//! anticlockwise viewed from above, and [`to_degrees`](HeadingU16::to_degrees)
+//! always returns a value in `[0, 360)`.
+//!
+//! | Type | Wire | Scale | Zero |
+//! |------|------|-------|------|
+//! | [`HeadingU16`] | `u16` | 32768 = 180° | 0 = 0° |
+//! | [`HeadingU8`] | `u8` | 128 = 180° | 0 = 0° |
+//! | [`ObjectHeading`] | `u8` | 128 = 180° | 128 = 0° (offset) |
+
 use std::fmt;
 
-/// Angular measurement stored as radians (f64).
-///
-/// - 0° points along world Y, 90° along world -X.
-/// - Values are not auto-normalized; use `normalize()` when needed.
-/// - Includes object-heading wire conversions.
-///
-/// Represents heading or direction in LFS game space. Internally stored as f64 radians
-/// for consistency across the codebase, with convenient conversions to/from degrees.
-/// Uses double precision to minimize cumulative errors in physics calculations and
-/// integration over time.
-///
-/// # Orientation
-/// - 0 = world Y direction** (forward/north)
-/// - 90 = world -X direction** (left/west)
-/// - 180 = -Y direction** (backward/south)
-/// - 270 = world X direction** (right/east)
-///
-/// Angles increase in the anti-clockwise direction when viewed from above.
-///
-/// # Wraparound
-/// Angles are **not** automatically normalized. A Heading created from 450 will
-/// preserve that value internally. Use [`normalize()`](Heading::normalize) to wrap
-/// angles to the 0->360 range if needed.
-///
-/// ```
-/// use insim_core::heading::Heading;
-///
-/// let over = Heading::from_degrees(450.0);
-/// assert!((over.to_degrees() - 450.0).abs() < 0.0001);  // Preserved as-is
-///
-/// let normalized = over.normalize();
-/// assert!((normalized.to_degrees() - 90.0).abs() < 0.0001);  // Wrapped to [0, 360)
-/// ```
-///
-/// # Examples
-/// ```
-/// use insim_core::heading::Heading;
-///
-/// let forward = Heading::from_degrees(0.0);    // Y direction
-/// let left = Heading::from_degrees(90.0);      // -X direction
-/// let backward = Heading::from_degrees(180.0); // -Y direction
-///
-/// assert_eq!(forward.to_degrees(), 0.0);
-/// assert_eq!(left.to_degrees(), 90.0);
-/// ```
-#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-pub struct Heading {
-    radians: f64,
-}
+macro_rules! define_heading {
+    (
+        $(#[$meta:meta])*
+        $name:ident, inner = $inner:ty, half_turn = $half:expr, zero_offset = $offset:expr
+    ) => {
+        $(#[$meta])*
+        ///
+        /// Stores the raw wire value; degree/radian conversions are accessors.
+        /// Decoding then encoding reproduces the original value exactly.
+        #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+        pub struct $name($inner);
 
-impl Heading {
-    /// Heading pointing along world Y (0).
-    ///
-    /// This is typically north/forward in LFS game coordinates.
-    pub const ZERO: Self = Self::from_radians(0.0);
+        impl $name {
+            /// Raw units representing a half turn (180°).
+            const HALF_TURN: u32 = $half;
+            /// Raw units in a full turn (360°).
+            const FULL_TURN: u32 = $half * 2;
+            /// Raw value representing 0°.
+            const ZERO_OFFSET: u32 = $offset;
 
-    /// Heading pointing north (world Y direction, 0).
-    pub const NORTH: Self = Self::from_radians(0.0);
+            const fn raw_for_degrees(deg: u32) -> $inner {
+                (((deg * Self::HALF_TURN / 180) + Self::ZERO_OFFSET) % Self::FULL_TURN) as $inner
+            }
 
-    /// Heading pointing east (world X direction, 270).
-    pub const EAST: Self = Self::from_radians(3.0 * std::f64::consts::FRAC_PI_2);
+            /// Heading of 0° (world Y / forward).
+            pub const ZERO: Self = Self(Self::raw_for_degrees(0));
+            /// 0° - world Y direction (forward/north).
+            pub const NORTH: Self = Self(Self::raw_for_degrees(0));
+            /// 270° - world X direction (right/east).
+            pub const EAST: Self = Self(Self::raw_for_degrees(270));
+            /// 180° - opposite of world Y (backward/south).
+            pub const SOUTH: Self = Self(Self::raw_for_degrees(180));
+            /// 90° - world -X direction (left/west).
+            pub const WEST: Self = Self(Self::raw_for_degrees(90));
 
-    /// Heading pointing south (opposite of world Y, 180).
-    pub const SOUTH: Self = Self::from_radians(std::f64::consts::PI);
+            /// Construct from the raw wire value (lossless).
+            pub const fn from_raw(raw: $inner) -> Self {
+                Self(raw)
+            }
 
-    /// Heading pointing west (opposite of world X, 90).
-    pub const WEST: Self = Self::from_radians(std::f64::consts::FRAC_PI_2);
+            /// The raw wire value (lossless).
+            pub const fn to_raw(self) -> $inner {
+                self.0
+            }
 
-    /// Consumes Heading, returning the inner radian value.
-    pub fn into_inner(self) -> f64 {
-        self.radians
-    }
+            /// Construct from degrees. Values outside `[0, 360)` wrap around - the
+            /// wire format cannot represent an un-normalised angle.
+            pub fn from_degrees(value: f64) -> Self {
+                let units = (value * (Self::HALF_TURN as f64 / 180.0)).round() as i64;
+                let raw = (units + Self::ZERO_OFFSET as i64).rem_euclid(Self::FULL_TURN as i64);
+                Self(raw as $inner)
+            }
 
-    /// Create Heading from radians.
-    ///
-    /// 0 radians = world Y direction (forward)
-    /// π/2 radians = world -X direction (left)
-    /// π radians = -Y direction (backward)
-    /// 3π/2 radians = world X direction (right)
-    pub const fn from_radians(value: f64) -> Self {
-        Self { radians: value }
-    }
+            /// The heading in degrees, in `[0, 360)`.
+            pub fn to_degrees(self) -> f64 {
+                let centred =
+                    (self.0 as i64 - Self::ZERO_OFFSET as i64).rem_euclid(Self::FULL_TURN as i64);
+                centred as f64 * 180.0 / Self::HALF_TURN as f64
+            }
 
-    /// Get the angle in radians.
-    ///
-    /// 0 radians = world Y direction (forward)
-    /// π/2 radians = world -X direction (left)
-    /// π radians = -Y direction (backward)
-    /// 3π/2 radians = world X direction (right)
-    pub const fn to_radians(&self) -> f64 {
-        self.radians
-    }
+            /// Construct from radians (wraps, see [`from_degrees`](Self::from_degrees)).
+            pub fn from_radians(value: f64) -> Self {
+                Self::from_degrees(value.to_degrees())
+            }
 
-    /// Create Heading from degrees.
-    ///
-    /// 0 = world Y direction (forward)
-    /// 90 = world -X direction (left)
-    /// 180 = -Y direction (backward)
-    /// 270 = world X direction (right)
-    pub const fn from_degrees(value: f64) -> Self {
-        Self {
-            radians: value * std::f64::consts::PI / 180.0,
+            /// The heading in radians, in `[0, 2π)`.
+            pub fn to_radians(self) -> f64 {
+                self.to_degrees().to_radians()
+            }
+
+            /// The opposite direction (180° rotation). Exact - a half-turn is a
+            /// whole number of wire units.
+            pub fn opposite(self) -> Self {
+                Self(self.0.wrapping_add(Self::HALF_TURN as $inner))
+            }
+
+            /// Normalise to `[0, 360)`. Wire headings are inherently normalised
+            /// (the raw integer wraps), so this returns `self`; it exists for
+            /// parity with floating-point angle APIs.
+            pub fn normalize(self) -> Self {
+                self
+            }
         }
-    }
 
-    /// Get the angle in degrees.
-    ///
-    /// 0 = world Y direction (forward)
-    /// 90 = world -X direction (left)
-    /// 180 = -Y direction (backward)
-    /// 270 = world X direction (right)
-    pub const fn to_degrees(&self) -> f64 {
-        self.radians * 180.0 / std::f64::consts::PI
-    }
-
-    /// Normalize the angle to the range 0->360.
-    ///
-    /// Useful when you need to compare directions or ensure angles are in a
-    /// canonical form.
-    ///
-    /// # Examples
-    /// ```
-    /// use insim_core::heading::Heading;
-    ///
-    /// // Over-rotation wraps back
-    /// let over = Heading::from_degrees(450.0);
-    /// assert!((over.normalize().to_degrees() - 90.0).abs() < 0.0001);
-    ///
-    /// // Negative angles wrap forward
-    /// let negative = Heading::from_degrees(-90.0);
-    /// assert!((negative.normalize().to_degrees() - 270.0).abs() < 0.0001);
-    ///
-    /// // Already normalized angles unchanged
-    /// let normal = Heading::from_degrees(45.0);
-    /// assert!((normal.normalize().to_degrees() - 45.0).abs() < 0.0001);
-    /// ```
-    pub fn normalize(&self) -> Heading {
-        let degrees = self.to_degrees();
-        let normalized = degrees % 360.0;
-        let normalized = if normalized < 0.0 {
-            normalized + 360.0
-        } else {
-            normalized
-        };
-        Heading::from_degrees(normalized)
-    }
-
-    /// Get the opposite direction (180 rotation).
-    ///
-    /// Returns the direction that is directly opposite, i.e., rotated 180.
-    ///
-    /// # Examples
-    /// ```
-    /// use insim_core::heading::Heading;
-    ///
-    /// let north = Heading::NORTH;
-    /// let south = north.opposite();
-    /// assert!((south.to_degrees() - 180.0).abs() < 0.0001);
-    ///
-    /// let east = Heading::EAST;
-    /// let west = east.opposite().normalize();
-    /// assert!((west.to_degrees() - 90.0).abs() < 0.0001);
-    /// ```
-    pub fn opposite(&self) -> Heading {
-        Heading::from_radians(self.radians + std::f64::consts::PI)
-    }
-
-    /// Convert from LFS object heading u8 to Heading.
-    ///
-    /// LFS encodes object headings as a u8 where 360 degrees is represented in 256 values:
-    /// Heading = (heading_in_degrees + 180) * 256 / 360
-    ///
-    /// Therefore: heading_in_degrees = (heading * 360 / 256) - 180
-    ///
-    /// Examples:
-    /// - 128 = 0 (world Y direction / forward)
-    /// - 192 = 90 (world -X direction / left)
-    /// - 0 = 180 (opposite of world Y direction / backward)
-    /// - 64 = -90 (world X direction / right)
-    pub const fn from_objectinfo_wire(heading: u8) -> Self {
-        let degrees = (heading as f64) * (360.0 / 256.0) - 180.0;
-        Self::from_degrees(degrees)
-    }
-
-    /// Convert Heading to LFS object heading u8.
-    ///
-    /// Returns a u8 in the range 0-255 representing the heading.
-    /// Uses the formula: Heading = (heading_in_degrees + 180) * 256 / 360
-    pub fn to_objectinfo_wire(&self) -> u8 {
-        let mut value = ((self.to_degrees() + 180.0) * 256.0 / 360.0).round() as i32;
-        // Handle wraparound: 256 should map to 0
-        if value == 256 {
-            value = 0;
+        impl Default for $name {
+            fn default() -> Self {
+                Self::ZERO
+            }
         }
-        value as u8
-    }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "{:.2}", self.to_degrees())
+            }
+        }
+
+        impl crate::Decode for $name {
+            fn decode(ctx: &mut crate::DecodeContext) -> Result<Self, crate::DecodeError> {
+                Ok(Self(ctx.decode::<$inner>("heading")?))
+            }
+        }
+
+        impl crate::Encode for $name {
+            fn encode(&self, ctx: &mut crate::EncodeContext) -> Result<(), crate::EncodeError> {
+                ctx.encode("heading", &self.0)
+            }
+        }
+    };
 }
 
-impl fmt::Display for Heading {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:.2}", self.to_degrees())
-    }
+define_heading! {
+    /// Heading as transmitted in `CompCar` (MCI) and `Cpp`: a `u16` where
+    /// 32768 = 180°, zero at 0.
+    HeadingU16, inner = u16, half_turn = 32768, zero_offset = 0
 }
 
-impl Default for Heading {
-    fn default() -> Self {
-        Self::ZERO
-    }
+define_heading! {
+    /// Heading as transmitted in `CarContact`/`ConInfo`: a `u8` where
+    /// 128 = 180°, zero at 0.
+    HeadingU8, inner = u8, half_turn = 128, zero_offset = 0
+}
+
+define_heading! {
+    /// Heading as transmitted in layout `ObjectInfo`: a `u8` where 128 = 180°
+    /// **and the zero-point is offset** so that raw 128 = 0°
+    /// (`raw = (degrees + 180) * 256 / 360`). This is why it is a distinct type
+    /// from [`HeadingU8`] despite the identical scale.
+    ///
+    /// - 128 = 0° (forward), 192 = 90°, 0 = 180°, 64 = 270°.
+    ObjectHeading, inner = u8, half_turn = 128, zero_offset = 128
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{Decode, Encode};
 
     #[test]
-    fn test_radians() {
-        assert_eq!(
-            Heading::from_radians(std::f64::consts::PI).to_degrees(),
-            180.0
-        );
+    fn test_headingu16_raw_roundtrip_exact() {
+        for raw in [0u16, 1, 16384, 32768, 49152, 65535] {
+            assert_eq!(HeadingU16::from_raw(raw).to_raw(), raw);
+        }
     }
 
     #[test]
-    fn test_degrees() {
-        assert!((Heading::from_degrees(180.0).to_radians() - std::f64::consts::PI).abs() < 0.001);
+    fn test_headingu16_degrees() {
+        assert_eq!(HeadingU16::from_raw(0).to_degrees(), 0.0);
+        assert_eq!(HeadingU16::from_raw(16384).to_degrees(), 90.0);
+        assert_eq!(HeadingU16::from_raw(32768).to_degrees(), 180.0);
+        assert_eq!(HeadingU16::from_degrees(90.0).to_raw(), 16384);
     }
 
     #[test]
-    fn test_zero() {
-        assert_eq!(Heading::ZERO.to_degrees(), 0.0);
-        assert_eq!(Heading::ZERO.to_radians(), 0.0);
+    fn test_headingu8_degrees() {
+        assert_eq!(HeadingU8::from_raw(0).to_degrees(), 0.0);
+        assert_eq!(HeadingU8::from_raw(64).to_degrees(), 90.0);
+        assert_eq!(HeadingU8::from_raw(128).to_degrees(), 180.0);
     }
 
     #[test]
-    fn test_roundtrip_degrees() {
-        let original = 45.0;
-        let direction = Heading::from_degrees(original);
-        assert!((direction.to_degrees() - original).abs() < 0.0001);
+    fn test_objectheading_offset() {
+        // raw 128 = 0°, 192 = 90°, 0 = 180°, 64 = 270°
+        assert_eq!(ObjectHeading::from_raw(128).to_degrees(), 0.0);
+        assert_eq!(ObjectHeading::from_raw(192).to_degrees(), 90.0);
+        assert_eq!(ObjectHeading::from_raw(0).to_degrees(), 180.0);
+        assert_eq!(ObjectHeading::from_raw(64).to_degrees(), 270.0);
+
+        // Encode side, including the 256 -> 0 wrap at 180°.
+        assert_eq!(ObjectHeading::from_degrees(0.0).to_raw(), 128);
+        assert_eq!(ObjectHeading::from_degrees(90.0).to_raw(), 192);
+        assert_eq!(ObjectHeading::from_degrees(180.0).to_raw(), 0);
+        assert_eq!(ObjectHeading::from_degrees(-90.0).to_raw(), 64);
     }
 
     #[test]
-    fn test_normalize_over_rotation() {
-        let over = Heading::from_degrees(450.0);
-        let normalized = over.normalize();
-        assert!((normalized.to_degrees() - 90.0).abs() < 0.0001);
+    fn test_raw_roundtrip_all_u8() {
+        // Every u8 must survive raw round-trip for both u8 heading types.
+        for raw in 0u8..=255 {
+            assert_eq!(HeadingU8::from_raw(raw).to_raw(), raw);
+            assert_eq!(ObjectHeading::from_raw(raw).to_raw(), raw);
+        }
     }
 
     #[test]
-    fn test_normalize_negative() {
-        let negative = Heading::from_degrees(-90.0);
-        let normalized = negative.normalize();
-        assert!((normalized.to_degrees() - 270.0).abs() < 0.0001);
+    fn test_opposite_exact() {
+        assert_eq!(HeadingU16::from_raw(0).opposite().to_raw(), 32768);
+        assert_eq!(HeadingU16::from_raw(32768).opposite().to_raw(), 0);
+        assert_eq!(HeadingU8::from_raw(10).opposite().to_raw(), 138);
+        // ObjectHeading 0° (raw 128) opposite is 180° (raw 0)
+        assert_eq!(ObjectHeading::from_raw(128).opposite().to_raw(), 0);
     }
 
     #[test]
-    fn test_normalize_already_normal() {
-        let normal = Heading::from_degrees(45.0);
-        let normalized = normal.normalize();
-        assert!((normalized.to_degrees() - 45.0).abs() < 0.0001);
+    fn test_cardinals() {
+        assert_eq!(HeadingU16::NORTH.to_degrees(), 0.0);
+        assert_eq!(HeadingU16::EAST.to_degrees(), 270.0);
+        assert_eq!(HeadingU16::SOUTH.to_degrees(), 180.0);
+        assert_eq!(HeadingU16::WEST.to_degrees(), 90.0);
+        assert_eq!(ObjectHeading::NORTH.to_raw(), 128);
+        assert_eq!(ObjectHeading::SOUTH.to_raw(), 0);
     }
 
     #[test]
-    fn test_normalize_zero() {
-        let zero = Heading::from_degrees(0.0);
-        let normalized = zero.normalize();
-        assert!((normalized.to_degrees() - 0.0).abs() < 0.0001);
+    fn test_default_is_zero_degrees() {
+        assert_eq!(HeadingU16::default().to_degrees(), 0.0);
+        assert_eq!(HeadingU8::default().to_degrees(), 0.0);
+        // ObjectHeading default must be 0° (raw 128), not raw 0 (which is 180°).
+        assert_eq!(ObjectHeading::default().to_raw(), 128);
+        assert_eq!(ObjectHeading::default().to_degrees(), 0.0);
     }
 
     #[test]
-    fn test_normalize_360() {
-        let full_rotation = Heading::from_degrees(360.0);
-        let normalized = full_rotation.normalize();
-        assert!((normalized.to_degrees() - 0.0).abs() < 0.0001);
-    }
-
-    #[test]
-    fn test_normalize_large_negative() {
-        let large_negative = Heading::from_degrees(-450.0);
-        let normalized = large_negative.normalize();
-        assert!((normalized.to_degrees() - 270.0).abs() < 0.0001);
-    }
-
-    #[test]
-    fn test_no_auto_normalize() {
-        // Verify that construction doesn't auto-normalize
-        let over = Heading::from_degrees(450.0);
-        assert!((over.to_degrees() - 450.0).abs() < 0.0001);
-    }
-
-    #[test]
-    fn test_from_u8_heading() {
-        // Test conversion from u8 heading using formula:
-        // heading_in_degrees = (heading * 360 / 256) - 180
-        let forward = Heading::from_objectinfo_wire(128);
-        assert!((forward.to_degrees() - 0.0).abs() < 0.0001);
-
-        let backward = Heading::from_objectinfo_wire(0);
-        // heading 0 gives -180, which is equivalent to 180 (differ by 360)
-        assert!((backward.to_degrees() - (-180.0)).abs() < 0.0001);
-
-        let left = Heading::from_objectinfo_wire(192);
-        assert!((left.to_degrees() - 90.0).abs() < 0.0001);
-
-        let right = Heading::from_objectinfo_wire(64);
-        assert!((right.to_degrees() - (-90.0)).abs() < 0.0001);
-    }
-
-    #[test]
-    fn test_to_u8_heading() {
-        // Test roundtrip conversion
-        let original = Heading::from_degrees(45.0);
-        let heading = original.to_objectinfo_wire();
-        let restored = Heading::from_objectinfo_wire(heading);
-        assert!((original.to_degrees() - restored.to_degrees()).abs() < 0.2);
-
-        // Test specific values using formula: Heading = (heading_in_degrees + 180) * 256 / 360
-        assert_eq!(Heading::from_degrees(0.0).to_objectinfo_wire(), 128);
-        // 180 wraps around: (180 + 180) * 256 / 360 = 256 -> 0
-        assert_eq!(Heading::from_degrees(180.0).to_objectinfo_wire(), 0);
-        assert_eq!(Heading::from_degrees(90.0).to_objectinfo_wire(), 192);
-        assert_eq!(Heading::from_degrees(-90.0).to_objectinfo_wire(), 64);
-    }
-
-    #[test]
-    fn test_cardinal_directions() {
-        assert!((Heading::NORTH.to_degrees() - 0.0).abs() < 0.0001);
-        assert!((Heading::EAST.to_degrees() - 270.0).abs() < 0.0001);
-        assert!((Heading::SOUTH.to_degrees() - 180.0).abs() < 0.0001);
-        assert!((Heading::WEST.to_degrees() - 90.0).abs() < 0.0001);
-    }
-
-    #[test]
-    fn test_opposite() {
-        let north = Heading::NORTH;
-        let south = north.opposite();
-        assert!((south.to_degrees() - 180.0).abs() < 0.0001);
-
-        let east = Heading::EAST;
-        let west = east.opposite().normalize();
-        assert!((west.to_degrees() - 90.0).abs() < 0.0001);
-    }
-
-    #[test]
-    fn test_opposite_roundtrip() {
-        let original = Heading::from_degrees(45.0);
-        let twice_opposite = original.opposite().opposite();
-        // Note: Heading doesn't auto-normalize, so opposite().opposite() adds 360
-        assert!((twice_opposite.to_degrees() - (original.to_degrees() + 360.0)).abs() < 0.0001);
-    }
-
-    #[test]
-    fn test_opposite_arbitrary_angle() {
-        let dir = Heading::from_degrees(123.45);
-        let opp = dir.opposite();
-        let expected = (123.45 + 180.0) % 360.0;
-        assert!((opp.to_degrees() - expected).abs() < 0.0001);
+    fn test_byte_roundtrip() {
+        for raw in [0u16, 123, 40000, 65535] {
+            let h = HeadingU16::from_raw(raw);
+            let bytes = h.to_bytes().unwrap();
+            assert_eq!(HeadingU16::decode_slice(&bytes).unwrap(), h);
+        }
+        for raw in [0u8, 1, 128, 255] {
+            let h = ObjectHeading::from_raw(raw);
+            let bytes = h.to_bytes().unwrap();
+            assert_eq!(ObjectHeading::decode_slice(&bytes).unwrap(), h);
+        }
     }
 }

--- a/insim_core/src/heading.rs
+++ b/insim_core/src/heading.rs
@@ -105,6 +105,12 @@ macro_rules! define_heading {
             /// Normalise to `[0, 360)`. Wire headings are inherently normalised
             /// (the raw integer wraps), so this returns `self`; it exists for
             /// parity with floating-point angle APIs.
+            ///
+            /// Note: the American spelling `normalize` is retained (rather than the
+            /// British `normalise` used elsewhere in this crate) to mirror the
+            /// wider Rust ecosystem - `glam`, `nalgebra`, and `std` all spell it
+            /// this way, and these headings interoperate with those libraries.
+            #[doc(alias = "normalise")]
             pub fn normalize(self) -> Self {
                 self
             }

--- a/insim_core/src/heading.rs
+++ b/insim_core/src/heading.rs
@@ -66,6 +66,11 @@ macro_rules! define_heading {
                 self.0
             }
 
+            /// Consumes `self`, returning the raw inner value (same as [`to_raw`](Self::to_raw)).
+            pub const fn into_inner(self) -> $inner {
+                self.0
+            }
+
             /// Construct from degrees. Values outside `[0, 360)` wrap around - the
             /// wire format cannot represent an un-normalised angle.
             pub fn from_degrees(value: f64) -> Self {

--- a/insim_core/src/object/armco.rs
+++ b/insim_core/src/object/armco.rs
@@ -1,7 +1,7 @@
 //! Armco 1-5 barrier object
 use crate::{
     DecodeError,
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -12,8 +12,8 @@ use crate::{
 pub struct Armco {
     /// Position
     pub xyz: ObjectCoordinate,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Colour (3 bits, 0-7)
     pub colour: u8,
     /// Mapping (4 bits, 0-15)
@@ -25,7 +25,7 @@ pub struct Armco {
 impl Armco {
     pub(super) fn new(raw: Raw) -> Result<Self, DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = raw.raw_colour();
         let mapping = raw.raw_mapping();
         let floating = raw.raw_floating();
@@ -48,11 +48,11 @@ impl ObjectInfoInner for Armco {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -65,6 +65,6 @@ impl ObjectInfoInner for Armco {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/bale.rs
+++ b/insim_core/src/object/bale.rs
@@ -1,6 +1,6 @@
 //! Bale objects
 use crate::{
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -11,8 +11,8 @@ use crate::{
 pub struct Bale {
     /// Position
     pub xyz: ObjectCoordinate,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Colour (3 bits, 0-7)
     pub colour: u8,
     /// Mapping (4 bits, 0-15)
@@ -24,7 +24,7 @@ pub struct Bale {
 impl Bale {
     pub(super) fn new(raw: Raw) -> Result<Self, crate::DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = raw.raw_colour();
         let mapping = raw.raw_mapping();
         let floating = raw.raw_floating();
@@ -47,11 +47,11 @@ impl ObjectInfoInner for Bale {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -64,6 +64,6 @@ impl ObjectInfoInner for Bale {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/banner.rs
+++ b/insim_core/src/object/banner.rs
@@ -1,6 +1,6 @@
 //! Banner objects
 use crate::{
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -42,8 +42,8 @@ impl From<u8> for BannerColour {
 pub struct Banner {
     /// Position
     pub xyz: ObjectCoordinate,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Colour (3 bits, 0-7)
     pub colour: BannerColour,
     /// Mapping (4 bits, 0-15)
@@ -55,7 +55,7 @@ pub struct Banner {
 impl Banner {
     pub(super) fn new(raw: Raw) -> Result<Self, crate::DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = BannerColour::from(raw.raw_colour());
         let mapping = raw.raw_mapping();
         let floating = raw.raw_floating();
@@ -78,11 +78,11 @@ impl ObjectInfoInner for Banner {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -95,6 +95,6 @@ impl ObjectInfoInner for Banner {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/barrier.rs
+++ b/insim_core/src/object/barrier.rs
@@ -1,7 +1,7 @@
 //! Barrier long object
 use crate::{
     DecodeError,
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -12,8 +12,8 @@ use crate::{
 pub struct Barrier {
     /// Position
     pub xyz: ObjectCoordinate,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Colour (3 bits, 0-7)
     pub colour: u8,
     /// Mapping (4 bits, 0-15)
@@ -25,7 +25,7 @@ pub struct Barrier {
 impl Barrier {
     pub(super) fn new(raw: Raw) -> Result<Self, DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = raw.raw_colour();
         let mapping = raw.raw_mapping();
         let floating = raw.raw_floating();
@@ -48,11 +48,11 @@ impl ObjectInfoInner for Barrier {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -65,6 +65,6 @@ impl ObjectInfoInner for Barrier {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/bin1.rs
+++ b/insim_core/src/object/bin1.rs
@@ -1,7 +1,7 @@
 //! Bin1 object
 use crate::{
     DecodeError,
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -42,8 +42,8 @@ impl From<u8> for Bin1Colour {
 pub struct Bin1 {
     /// Position
     pub xyz: ObjectCoordinate,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Colour (3 bits, 0-7)
     pub colour: Bin1Colour,
     /// Mapping (4 bits, 0-15)
@@ -55,7 +55,7 @@ pub struct Bin1 {
 impl Bin1 {
     pub(super) fn new(raw: Raw) -> Result<Self, DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = Bin1Colour::from(raw.raw_colour());
         let mapping = raw.raw_mapping();
         let floating = raw.raw_floating();
@@ -78,11 +78,11 @@ impl ObjectInfoInner for Bin1 {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -95,6 +95,6 @@ impl ObjectInfoInner for Bin1 {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/bin2.rs
+++ b/insim_core/src/object/bin2.rs
@@ -1,7 +1,7 @@
 //! Bin2 object
 use crate::{
     DecodeError,
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -42,8 +42,8 @@ impl From<u8> for Bin2Colour {
 pub struct Bin2 {
     /// Position
     pub xyz: ObjectCoordinate,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Colour (3 bits, 0-7)
     pub colour: Bin2Colour,
     /// Mapping (4 bits, 0-15)
@@ -55,7 +55,7 @@ pub struct Bin2 {
 impl Bin2 {
     pub(super) fn new(raw: Raw) -> Result<Self, DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = Bin2Colour::from(raw.raw_colour());
         let mapping = raw.raw_mapping();
         let floating = raw.raw_floating();
@@ -78,11 +78,11 @@ impl ObjectInfoInner for Bin2 {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -95,6 +95,6 @@ impl ObjectInfoInner for Bin2 {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/chalk.rs
+++ b/insim_core/src/object/chalk.rs
@@ -1,7 +1,7 @@
 //! Chalk ahead object
 use crate::{
     DecodeError,
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -52,8 +52,8 @@ pub struct Chalk {
     pub xyz: ObjectCoordinate,
     /// Colour
     pub colour: ChalkColour,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Floating
     pub floating: bool,
 }
@@ -61,7 +61,7 @@ pub struct Chalk {
 impl Chalk {
     pub(super) fn new(raw: Raw) -> Result<Self, DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = ChalkColour::from(raw.raw_colour());
         let floating = raw.raw_floating();
         Ok(Self {
@@ -81,11 +81,11 @@ impl ObjectInfoInner for Chalk {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -98,6 +98,6 @@ impl ObjectInfoInner for Chalk {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/chevron.rs
+++ b/insim_core/src/object/chevron.rs
@@ -1,6 +1,6 @@
 //! Cone1 objects
 use crate::{
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -38,8 +38,8 @@ pub struct Chevron {
     pub xyz: ObjectCoordinate,
     /// Colour
     pub colour: ChevronColour,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Floating
     pub floating: bool,
 }
@@ -47,7 +47,7 @@ pub struct Chevron {
 impl Chevron {
     pub(super) fn new(raw: Raw) -> Result<Self, crate::DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = ChevronColour::from(raw.raw_colour());
         let floating = raw.raw_floating();
         Ok(Self {
@@ -68,11 +68,11 @@ impl ObjectInfoInner for Chevron {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -85,6 +85,6 @@ impl ObjectInfoInner for Chevron {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/concrete.rs
+++ b/insim_core/src/object/concrete.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     DecodeError,
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -284,14 +284,14 @@ pub struct ConcreteSlab {
     pub length: ConcreteWidthLength,
     /// Pitch
     pub pitch: ConcretePitch,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
 }
 
 impl ConcreteSlab {
     pub(super) fn new(raw: Raw) -> Result<Self, DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let width = ConcreteWidthLength::try_from(raw.flags & 0x03)?;
         let length = ConcreteWidthLength::try_from((raw.flags & 0x0c) >> 2)?;
         let pitch = ConcretePitch::try_from((raw.flags & 0xf0) >> 4)?;
@@ -313,16 +313,16 @@ impl ObjectInfoInner for ConcreteSlab {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }
 
@@ -339,14 +339,14 @@ pub struct ConcreteRamp {
     pub length: ConcreteWidthLength,
     /// Height
     pub height: ConcreteHeight,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
 }
 
 impl ConcreteRamp {
     pub(super) fn new(raw: Raw) -> Result<Self, DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let width = ConcreteWidthLength::try_from(raw.flags & 0x03)?;
         let length = ConcreteWidthLength::try_from((raw.flags & 0x0c) >> 2)?;
         let height = ConcreteHeight::try_from((raw.flags & 0xf0) >> 4)?;
@@ -368,16 +368,16 @@ impl ObjectInfoInner for ConcreteRamp {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }
 
@@ -394,14 +394,14 @@ pub struct ConcreteWall {
     pub length: ConcreteWidthLength,
     /// Height
     pub height: ConcreteHeight,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
 }
 
 impl ConcreteWall {
     pub(super) fn new(raw: Raw) -> Result<Self, DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = ConcreteColour::try_from(raw.flags & 0x03)?;
         let length = ConcreteWidthLength::try_from((raw.flags & 0x0c) >> 2)?;
         let height = ConcreteHeight::try_from((raw.flags & 0xf0) >> 4)?;
@@ -423,16 +423,16 @@ impl ObjectInfoInner for ConcreteWall {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }
 
@@ -449,14 +449,14 @@ pub struct ConcretePillar {
     pub y: Size,
     /// Height
     pub height: ConcreteHeight,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
 }
 
 impl ConcretePillar {
     pub(super) fn new(raw: Raw) -> Result<Self, DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let x = Size::try_from(raw.flags & 0x03)?;
         let y = Size::try_from((raw.flags & 0x0c) >> 2)?;
         let height = ConcreteHeight::try_from((raw.flags & 0xf0) >> 4)?;
@@ -478,16 +478,16 @@ impl ObjectInfoInner for ConcretePillar {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }
 
@@ -504,14 +504,14 @@ pub struct ConcreteSlabWall {
     pub length: ConcreteWidthLength,
     /// Pitch
     pub pitch: ConcretePitch,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
 }
 
 impl ConcreteSlabWall {
     pub(super) fn new(raw: Raw) -> Result<Self, DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = ConcreteColour::try_from(raw.flags & 0x03)?;
         let length = ConcreteWidthLength::try_from((raw.flags & 0x0c) >> 2)?;
         let pitch = ConcretePitch::try_from((raw.flags & 0xf0) >> 4)?;
@@ -533,16 +533,16 @@ impl ObjectInfoInner for ConcreteSlabWall {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }
 
@@ -559,14 +559,14 @@ pub struct ConcreteRampWall {
     pub length: ConcreteWidthLength,
     /// Height
     pub height: ConcreteHeight,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
 }
 
 impl ConcreteRampWall {
     pub(super) fn new(raw: Raw) -> Result<Self, DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = ConcreteColour::try_from(raw.flags & 0x03)?;
         let length = ConcreteWidthLength::try_from((raw.flags & 0x0c) >> 2)?;
         let height = ConcreteHeight::try_from((raw.flags & 0xf0) >> 4)?;
@@ -588,16 +588,16 @@ impl ObjectInfoInner for ConcreteRampWall {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }
 
@@ -614,14 +614,14 @@ pub struct ConcreteShortSlabWall {
     pub y: Size,
     /// Pitch
     pub pitch: ConcretePitch,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
 }
 
 impl ConcreteShortSlabWall {
     pub(super) fn new(raw: Raw) -> Result<Self, DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = ConcreteColour::try_from(raw.flags & 0x03)?;
         let y = Size::try_from((raw.flags & 0x0c) >> 2)?;
         let pitch = ConcretePitch::try_from((raw.flags & 0xf0) >> 4)?;
@@ -643,16 +643,16 @@ impl ObjectInfoInner for ConcreteShortSlabWall {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }
 
@@ -669,14 +669,14 @@ pub struct ConcreteWedge {
     pub length: ConcreteWidthLength,
     /// Angle
     pub angle: ConcreteAngle,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
 }
 
 impl ConcreteWedge {
     pub(super) fn new(raw: Raw) -> Result<Self, DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = ConcreteColour::try_from(raw.flags & 0x03)?;
         let length = ConcreteWidthLength::try_from((raw.flags & 0x0c) >> 2)?;
         let angle = ConcreteAngle::try_from((raw.flags & 0xf0) >> 4)?;
@@ -698,15 +698,15 @@ impl ObjectInfoInner for ConcreteWedge {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/cones.rs
+++ b/insim_core/src/object/cones.rs
@@ -1,6 +1,6 @@
 //! Cone1 objects
 use crate::{
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -53,8 +53,8 @@ pub struct Cone {
     pub xyz: ObjectCoordinate,
     /// Colour
     pub colour: ConeColour,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Floating
     pub floating: bool,
 }
@@ -62,7 +62,7 @@ pub struct Cone {
 impl Cone {
     pub(super) fn new(raw: Raw) -> Result<Self, crate::DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = ConeColour::from(raw.raw_colour());
         let floating = raw.raw_floating();
         Ok(Self {
@@ -83,11 +83,11 @@ impl ObjectInfoInner for Cone {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -100,6 +100,6 @@ impl ObjectInfoInner for Cone {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/control.rs
+++ b/insim_core/src/object/control.rs
@@ -1,7 +1,7 @@
 //! Control objects
 
 use crate::{
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -14,8 +14,8 @@ pub struct Control {
     pub xyz: ObjectCoordinate,
     /// Kind of Control Object
     pub kind: ControlKind,
-    /// Heading
-    pub heading: Heading,
+    /// ObjectHeading
+    pub heading: ObjectHeading,
     /// Floating?
     pub floating: bool,
 }
@@ -23,7 +23,7 @@ pub struct Control {
 impl Control {
     pub(super) fn new(raw: Raw) -> Result<Self, crate::DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let position_bits = raw.flags & 0b11;
         let half_width = (raw.flags >> 2) & 0b11111;
         let floating = raw.raw_floating();
@@ -65,11 +65,11 @@ impl ObjectInfoInner for Control {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -82,7 +82,7 @@ impl ObjectInfoInner for Control {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }
 

--- a/insim_core/src/object/insim.rs
+++ b/insim_core/src/object/insim.rs
@@ -1,6 +1,6 @@
 //! Insim objects
 use crate::{
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -43,8 +43,8 @@ pub struct InsimCheckpoint {
     pub xyz: ObjectCoordinate,
     /// Kind of checkpoint
     pub kind: InsimCheckpointKind,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Floating
     pub floating: bool,
 }
@@ -52,7 +52,7 @@ pub struct InsimCheckpoint {
 impl InsimCheckpoint {
     pub(super) fn new(raw: Raw) -> Result<Self, crate::DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let kind = InsimCheckpointKind::try_from(raw.flags)?;
         let floating = raw.raw_floating();
         Ok(Self {
@@ -73,11 +73,11 @@ impl ObjectInfoInner for InsimCheckpoint {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -90,7 +90,7 @@ impl ObjectInfoInner for InsimCheckpoint {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }
 

--- a/insim_core/src/object/kerb.rs
+++ b/insim_core/src/object/kerb.rs
@@ -1,6 +1,6 @@
 //! Kerb objects
 use crate::{
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -78,8 +78,8 @@ impl From<u8> for KerbColour {
 pub struct Kerb {
     /// Position
     pub xyz: ObjectCoordinate,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Colour (3 bits, 0-7)
     pub colour: u8,
     /// Mapping
@@ -91,7 +91,7 @@ pub struct Kerb {
 impl Kerb {
     pub(super) fn new(raw: Raw) -> Result<Self, crate::DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = raw.raw_colour();
         let mapping = KerbColour::from(raw.raw_mapping());
         let floating = raw.raw_floating();
@@ -114,11 +114,11 @@ impl ObjectInfoInner for Kerb {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -131,6 +131,6 @@ impl ObjectInfoInner for Kerb {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/letterboard_rb.rs
+++ b/insim_core/src/object/letterboard_rb.rs
@@ -1,7 +1,7 @@
 //! Letterboard RB (Red/Blue) objects
 use crate::{
     DecodeError, DecodeErrorKind,
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -278,8 +278,8 @@ pub struct LetterboardRB {
     pub xyz: ObjectCoordinate,
     /// Colour
     pub colour: LetterboardRBColour,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Mapping (6 bits, 0-63)
     pub character: Character,
     /// Floating
@@ -289,7 +289,7 @@ pub struct LetterboardRB {
 impl LetterboardRB {
     pub(super) fn new(raw: Raw) -> Result<Self, crate::DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = LetterboardRBColour::from(raw.flags);
         let mapping = (raw.flags >> 1) & 0x3f;
         let character = Character::try_from(mapping)?;
@@ -313,11 +313,11 @@ impl ObjectInfoInner for LetterboardRB {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -330,6 +330,6 @@ impl ObjectInfoInner for LetterboardRB {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/letterboard_wy.rs
+++ b/insim_core/src/object/letterboard_wy.rs
@@ -1,7 +1,7 @@
 //! Letterboard WY (White/Yellow) objects
 use super::letterboard_rb::Character;
 use crate::{
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -38,8 +38,8 @@ pub struct LetterboardWY {
     pub xyz: ObjectCoordinate,
     /// Colour
     pub colour: LetterboardWYColour,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Mapping (6 bits, 0-63)
     pub character: Character,
     /// Floating
@@ -49,7 +49,7 @@ pub struct LetterboardWY {
 impl LetterboardWY {
     pub(super) fn new(raw: Raw) -> Result<Self, crate::DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = LetterboardWYColour::from(raw.flags);
         let mapping = (raw.flags >> 1) & 0x3f;
         let character = Character::try_from(mapping)?;
@@ -73,11 +73,11 @@ impl ObjectInfoInner for LetterboardWY {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -90,6 +90,6 @@ impl ObjectInfoInner for LetterboardWY {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/marker.rs
+++ b/insim_core/src/object/marker.rs
@@ -1,7 +1,7 @@
 //! Marker objects
 use crate::{
     DecodeError, DecodeErrorKind,
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -70,8 +70,8 @@ pub struct MarkerCorner {
     pub xyz: ObjectCoordinate,
     /// Kind of marker
     pub kind: MarkerCornerKind,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Floating
     pub floating: bool,
 }
@@ -79,7 +79,7 @@ pub struct MarkerCorner {
 impl MarkerCorner {
     pub(super) fn new(raw: Raw) -> Result<Self, crate::DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let kind = MarkerCornerKind::try_from(raw.raw_mapping())?;
         let floating = raw.raw_floating();
         Ok(Self {
@@ -99,11 +99,11 @@ impl ObjectInfoInner for MarkerCorner {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -116,7 +116,7 @@ impl ObjectInfoInner for MarkerCorner {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }
 
@@ -169,8 +169,8 @@ pub struct MarkerDistance {
     pub xyz: ObjectCoordinate,
     /// Kind of distance marker
     pub kind: MarkerDistanceKind,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Floating
     pub floating: bool,
 }
@@ -178,7 +178,7 @@ pub struct MarkerDistance {
 impl MarkerDistance {
     pub(super) fn new(raw: Raw) -> Result<Self, crate::DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let kind = MarkerDistanceKind::try_from(raw.raw_mapping())?;
         let floating = raw.raw_floating();
         Ok(Self {
@@ -198,11 +198,11 @@ impl ObjectInfoInner for MarkerDistance {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -215,6 +215,6 @@ impl ObjectInfoInner for MarkerDistance {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/marquee.rs
+++ b/insim_core/src/object/marquee.rs
@@ -1,6 +1,6 @@
 //! Marquee objects
 use crate::{
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -11,8 +11,8 @@ use crate::{
 pub struct Marquee {
     /// Position
     pub xyz: ObjectCoordinate,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Colour (3 bits, 0-7)
     pub colour: u8,
     /// Mapping (4 bits, 0-15)
@@ -24,7 +24,7 @@ pub struct Marquee {
 impl Marquee {
     pub(super) fn new(raw: Raw) -> Result<Self, crate::DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = raw.raw_colour();
         let mapping = raw.raw_mapping();
         let floating = raw.raw_floating();
@@ -47,11 +47,11 @@ impl ObjectInfoInner for Marquee {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -64,6 +64,6 @@ impl ObjectInfoInner for Marquee {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/marshal.rs
+++ b/insim_core/src/object/marshal.rs
@@ -1,6 +1,6 @@
 //! Marshal objects
 use crate::{
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -14,8 +14,8 @@ pub struct Marshal {
     /// Kind of Marshal
     pub kind: MarshalKind,
     /// Flags: watching/left/right
-    /// Heading
-    pub heading: Heading,
+    /// ObjectHeading
+    pub heading: ObjectHeading,
     /// Floating?
     pub floating: bool,
 }
@@ -23,7 +23,7 @@ pub struct Marshal {
 impl Marshal {
     pub(super) fn new(raw: Raw) -> Result<Self, crate::DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let kind = MarshalKind::try_from(raw.flags)?;
         let floating = raw.raw_floating();
 
@@ -44,11 +44,11 @@ impl ObjectInfoInner for Marshal {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -61,7 +61,7 @@ impl ObjectInfoInner for Marshal {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }
 

--- a/insim_core/src/object/mod.rs
+++ b/insim_core/src/object/mod.rs
@@ -42,17 +42,17 @@ mod tests;
 pub use object_coordinate::ObjectCoordinate;
 
 use crate::{
-    Decode, DecodeContext, DecodeError, Encode, EncodeContext, EncodeError, heading::Heading,
+    Decode, DecodeContext, DecodeError, Encode, EncodeContext, EncodeError, heading::ObjectHeading,
 };
 
 trait ObjectInfoInner {
     fn flags(&self) -> u8;
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         None
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         None
     }
 
@@ -65,9 +65,7 @@ trait ObjectInfoInner {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading()
-            .map(|h| h.to_objectinfo_wire())
-            .unwrap_or_default()
+        self.heading().map(|h| h.to_raw()).unwrap_or_default()
     }
 }
 
@@ -216,7 +214,7 @@ macro_rules! define_object_info {
             }
 
             /// Get mutable heading if this object has one
-            pub fn heading_mut(&mut self) -> Option<&mut Heading> {
+            pub fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
                 match self {
                     $(
                         ObjectInfo::$variant(i) => i.heading_mut(),
@@ -226,7 +224,7 @@ macro_rules! define_object_info {
             }
 
             /// Get heading if this object has one
-            pub fn heading(&self) -> Option<Heading> {
+            pub fn heading(&self) -> Option<ObjectHeading> {
                 match self {
                     $(
                         ObjectInfo::$variant(i) => i.heading(),

--- a/insim_core/src/object/object_coordinate.rs
+++ b/insim_core/src/object/object_coordinate.rs
@@ -18,21 +18,25 @@ impl ObjectCoordinate {
     const SCALE: i16 = 16;
 
     /// X (in metres)
+    #[doc(alias = "x_meters")]
     pub fn x_metres(&self) -> f32 {
         self.x as f32 / Self::SCALE as f32
     }
 
     /// Y (in metres)
+    #[doc(alias = "y_meters")]
     pub fn y_metres(&self) -> f32 {
         self.y as f32 / Self::SCALE as f32
     }
 
     /// Z (in metres)
+    #[doc(alias = "z_meters")]
     pub fn z_metres(&self) -> f32 {
         self.z as f32 / 4.0
     }
 
     /// X, Y, Z (in metres)
+    #[doc(alias = "xyz_meters")]
     pub fn xyz_metres(&self) -> (f32, f32, f32) {
         (self.x_metres(), self.y_metres(), self.z_metres())
     }
@@ -64,6 +68,7 @@ impl ObjectCoordinate {
     }
 
     /// Convert to glam DVec3, where xyz are in metres
+    #[doc(alias = "to_dvec3_meters")]
     pub fn to_dvec3_metres(&self) -> glam::DVec3 {
         glam::DVec3 {
             x: (self.x as f64 / 16.0),
@@ -73,6 +78,7 @@ impl ObjectCoordinate {
     }
 
     /// Convert from glam DVec3, where xyz are in metres
+    #[doc(alias = "from_dvec3_meters")]
     pub fn from_dvec3_metres(other: glam::DVec3) -> Self {
         Self {
             x: (other.x * 16.0).round() as i16,
@@ -82,6 +88,7 @@ impl ObjectCoordinate {
     }
 
     /// Convert to glam Vec3, where xyz are in metres
+    #[doc(alias = "to_vec3_meters")]
     pub fn to_vec3_metres(&self) -> glam::Vec3 {
         glam::Vec3 {
             x: (self.x as f32 / 16.0),
@@ -91,6 +98,7 @@ impl ObjectCoordinate {
     }
 
     /// Convert from glam Vec3, where xyz are in metres
+    #[doc(alias = "from_vec3_meters")]
     pub fn from_vec3_metres(other: glam::Vec3) -> Self {
         Self {
             x: (other.x * 16.0).round() as i16,

--- a/insim_core/src/object/painted.rs
+++ b/insim_core/src/object/painted.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 
 use crate::{
     DecodeError, DecodeErrorKind,
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -277,8 +277,8 @@ pub struct Letters {
     pub colour: PaintColour,
     /// Character
     pub character: Character,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Floating
     pub floating: bool,
 }
@@ -286,7 +286,7 @@ pub struct Letters {
 impl Letters {
     pub(super) fn new(raw: Raw) -> Result<Self, crate::DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = PaintColour::from(raw.flags);
         let character = Character::try_from(raw.flags)?;
         let floating = raw.raw_floating();
@@ -310,11 +310,11 @@ impl ObjectInfoInner for Letters {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -327,7 +327,7 @@ impl ObjectInfoInner for Letters {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }
 
@@ -380,8 +380,8 @@ pub struct Arrows {
     pub colour: PaintColour,
     /// Arrow
     pub arrow: Arrow,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Floating
     pub floating: bool,
 }
@@ -389,7 +389,7 @@ pub struct Arrows {
 impl Arrows {
     pub(super) fn new(raw: Raw) -> Result<Self, crate::DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = PaintColour::from(raw.flags);
         let arrow = Arrow::try_from(raw.flags)?;
         let floating = raw.raw_floating();
@@ -413,11 +413,11 @@ impl ObjectInfoInner for Arrows {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -430,6 +430,6 @@ impl ObjectInfoInner for Arrows {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/pit.rs
+++ b/insim_core/src/object/pit.rs
@@ -1,7 +1,7 @@
 //! Pit stop box object
 use crate::{
     DecodeError,
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -12,8 +12,8 @@ use crate::{
 pub struct PitStopBox {
     /// Position
     pub xyz: ObjectCoordinate,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Colour (3 bits, 0-7)
     pub colour: u8,
     /// Mapping (4 bits, 0-15)
@@ -25,7 +25,7 @@ pub struct PitStopBox {
 impl PitStopBox {
     pub(super) fn new(raw: Raw) -> Result<Self, DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = raw.raw_colour();
         let mapping = raw.raw_mapping();
         let floating = raw.raw_floating();
@@ -48,11 +48,11 @@ impl ObjectInfoInner for PitStopBox {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -65,6 +65,6 @@ impl ObjectInfoInner for PitStopBox {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/pit_start_point.rs
+++ b/insim_core/src/object/pit_start_point.rs
@@ -1,6 +1,6 @@
 //! Pit start point object
 use crate::{
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -12,8 +12,8 @@ use crate::{
 pub struct PitStartPoint {
     /// Position
     pub xyz: ObjectCoordinate,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Position index (0-47, representing start positions 1-48)
     pub index: u8,
     /// Floating
@@ -23,7 +23,7 @@ pub struct PitStartPoint {
 impl PitStartPoint {
     pub(super) fn new(raw: Raw) -> Result<Self, crate::DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let pos_index = raw.flags & 0x3f;
         let floating = raw.raw_floating();
         Ok(Self {
@@ -43,11 +43,11 @@ impl ObjectInfoInner for PitStartPoint {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -60,6 +60,6 @@ impl ObjectInfoInner for PitStartPoint {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/post.rs
+++ b/insim_core/src/object/post.rs
@@ -1,6 +1,6 @@
 //! Post objects
 use crate::{
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -43,8 +43,8 @@ impl From<u8> for PostColour {
 pub struct Post {
     /// Position
     pub xyz: ObjectCoordinate,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Colour (3 bits, 0-7)
     pub colour: PostColour,
     /// Mapping (4 bits, 0-15)
@@ -56,7 +56,7 @@ pub struct Post {
 impl Post {
     pub(super) fn new(raw: Raw) -> Result<Self, crate::DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = PostColour::from(raw.raw_colour());
         let mapping = raw.raw_mapping();
         let floating = raw.raw_floating();
@@ -79,11 +79,11 @@ impl ObjectInfoInner for Post {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -96,6 +96,6 @@ impl ObjectInfoInner for Post {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/railing.rs
+++ b/insim_core/src/object/railing.rs
@@ -1,7 +1,7 @@
 //! Railing1 object
 use crate::{
     DecodeError,
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -12,8 +12,8 @@ use crate::{
 pub struct Railing {
     /// Position
     pub xyz: ObjectCoordinate,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Colour (3 bits, 0-7)
     pub colour: u8,
     /// Mapping (4 bits, 0-15)
@@ -25,7 +25,7 @@ pub struct Railing {
 impl Railing {
     pub(super) fn new(raw: Raw) -> Result<Self, DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = raw.raw_colour();
         let mapping = raw.raw_mapping();
         let floating = raw.raw_floating();
@@ -48,11 +48,11 @@ impl ObjectInfoInner for Railing {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -65,6 +65,6 @@ impl ObjectInfoInner for Railing {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/ramp.rs
+++ b/insim_core/src/object/ramp.rs
@@ -1,7 +1,7 @@
 //! Ramp1 object
 use crate::{
     DecodeError,
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -12,8 +12,8 @@ use crate::{
 pub struct Ramp {
     /// Position
     pub xyz: ObjectCoordinate,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Colour (3 bits, 0-7)
     pub colour: u8,
     /// Mapping (4 bits, 0-15)
@@ -25,7 +25,7 @@ pub struct Ramp {
 impl Ramp {
     pub(super) fn new(raw: Raw) -> Result<Self, DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = raw.raw_colour();
         let mapping = raw.raw_mapping();
         let floating = raw.raw_floating();
@@ -48,11 +48,11 @@ impl ObjectInfoInner for Ramp {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -65,6 +65,6 @@ impl ObjectInfoInner for Ramp {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/sign_metal.rs
+++ b/insim_core/src/object/sign_metal.rs
@@ -1,7 +1,7 @@
 //! Metal sign objects
 use crate::{
     DecodeError, DecodeErrorKind,
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -62,8 +62,8 @@ pub struct SignMetal {
     pub xyz: ObjectCoordinate,
     /// Kind
     pub kind: MetalSignKind,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Colour (3 bits, 0-7)
     pub colour: u8,
     /// Floating
@@ -73,7 +73,7 @@ pub struct SignMetal {
 impl SignMetal {
     pub(super) fn new(raw: Raw) -> Result<Self, crate::DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let kind = MetalSignKind::try_from(raw.raw_mapping())?;
         let colour = raw.raw_colour();
         let floating = raw.raw_floating();
@@ -96,11 +96,11 @@ impl ObjectInfoInner for SignMetal {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -113,6 +113,6 @@ impl ObjectInfoInner for SignMetal {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/sign_speed.rs
+++ b/insim_core/src/object/sign_speed.rs
@@ -1,7 +1,7 @@
 //! Speed sign objects
 use crate::{
     DecodeError, DecodeErrorKind,
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -50,8 +50,8 @@ pub struct SignSpeed {
     pub xyz: ObjectCoordinate,
     /// Mapping
     pub mapping: SpeedSignMapping,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Colour (3 bits, 0-7)
     pub colour: u8,
     /// Floating
@@ -61,7 +61,7 @@ pub struct SignSpeed {
 impl SignSpeed {
     pub(super) fn new(raw: Raw) -> Result<Self, crate::DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let mapping = SpeedSignMapping::try_from(raw.raw_mapping())?;
         let colour = raw.raw_colour();
         let floating = raw.raw_floating();
@@ -84,11 +84,11 @@ impl ObjectInfoInner for SignSpeed {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -101,6 +101,6 @@ impl ObjectInfoInner for SignSpeed {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/speed_hump.rs
+++ b/insim_core/src/object/speed_hump.rs
@@ -1,7 +1,7 @@
 //! Speed hump 10m object
 use crate::{
     DecodeError,
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -12,8 +12,8 @@ use crate::{
 pub struct SpeedHump {
     /// Position
     pub xyz: ObjectCoordinate,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Colour (3 bits, 0-7)
     pub colour: u8,
     /// Mapping (4 bits, 0-15)
@@ -25,7 +25,7 @@ pub struct SpeedHump {
 impl SpeedHump {
     pub(super) fn new(raw: Raw) -> Result<Self, DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = raw.raw_colour();
         let mapping = raw.raw_mapping();
         let floating = raw.raw_floating();
@@ -48,11 +48,11 @@ impl ObjectInfoInner for SpeedHump {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -65,6 +65,6 @@ impl ObjectInfoInner for SpeedHump {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/start_lights.rs
+++ b/insim_core/src/object/start_lights.rs
@@ -1,7 +1,7 @@
 //! StartLights1 object
 use crate::{
     DecodeError,
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -12,8 +12,8 @@ use crate::{
 pub struct StartLights {
     /// Position
     pub xyz: ObjectCoordinate,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// identifier
     pub identifier: u8,
     /// Floating
@@ -23,7 +23,7 @@ pub struct StartLights {
 impl StartLights {
     pub(super) fn new(raw: Raw) -> Result<Self, DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let identifier = raw.flags & 0x3F;
         let floating = raw.raw_floating();
         Ok(Self {
@@ -43,11 +43,11 @@ impl ObjectInfoInner for StartLights {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -60,6 +60,6 @@ impl ObjectInfoInner for StartLights {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/start_position.rs
+++ b/insim_core/src/object/start_position.rs
@@ -1,6 +1,6 @@
 //! Start Position objects
 use crate::{
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -11,8 +11,8 @@ use crate::{
 pub struct StartPosition {
     /// Position
     pub xyz: ObjectCoordinate,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Position index (0-47, representing start positions 1-48)
     pub index: u8,
     /// Floating
@@ -22,7 +22,7 @@ pub struct StartPosition {
 impl StartPosition {
     pub(super) fn new(raw: Raw) -> Result<Self, crate::DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let pos_index = raw.flags & 0x3f;
         let floating = raw.raw_floating();
         Ok(Self {
@@ -42,11 +42,11 @@ impl ObjectInfoInner for StartPosition {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -59,6 +59,6 @@ impl ObjectInfoInner for StartPosition {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/tests.rs
+++ b/insim_core/src/object/tests.rs
@@ -805,3 +805,19 @@ fn test_coordinate_equality() {
 
     assert_eq!(coord1, coord2);
 }
+
+#[cfg(feature = "glam")]
+#[test]
+fn test_object_coordinate_metres_constructors_round_not_truncate() {
+    // x,y use 16 units = 1m; z uses 4 units = 1m. Fractional metres must scale,
+    // not truncate to whole metres.
+    let c = ObjectCoordinate::from_dvec3_metres(glam::DVec3::new(1.5, -2.25, 3.25));
+    assert_eq!(c.x, 24); // 1.5 * 16
+    assert_eq!(c.y, -36); // -2.25 * 16
+    assert_eq!(c.z, 13); // 3.25 * 4
+
+    let c = ObjectCoordinate::from_vec3_metres(glam::Vec3::new(1.5, -2.25, 3.25));
+    assert_eq!(c.x, 24);
+    assert_eq!(c.y, -36);
+    assert_eq!(c.z, 13);
+}

--- a/insim_core/src/object/tests.rs
+++ b/insim_core/src/object/tests.rs
@@ -1,4 +1,4 @@
-use crate::{heading::Heading, object::*};
+use crate::{heading::ObjectHeading, object::*};
 
 fn raw_flags(flags: u8) -> Raw {
     Raw {
@@ -9,12 +9,12 @@ fn raw_flags(flags: u8) -> Raw {
     }
 }
 
-fn raw_with(xyz: ObjectCoordinate, flags: u8, heading: Heading) -> Raw {
+fn raw_with(xyz: ObjectCoordinate, flags: u8, heading: ObjectHeading) -> Raw {
     Raw {
         index: 0,
         xyz,
         flags,
-        heading: heading.to_objectinfo_wire(),
+        heading: heading.to_raw(),
     }
 }
 
@@ -30,7 +30,7 @@ fn raw_with_heading_u8(xyz: ObjectCoordinate, flags: u8, heading: u8) -> Raw {
 #[test]
 fn test_armco1_basic_creation() {
     let coord = ObjectCoordinate::new(100, 200, 50);
-    let heading = Heading::from_degrees(45.0);
+    let heading = ObjectHeading::from_degrees(45.0);
     let armco = armco::Armco {
         xyz: coord,
         heading,
@@ -51,7 +51,7 @@ fn test_armco1_basic_creation() {
 fn test_armco1_floating() {
     let armco = armco::Armco {
         xyz: ObjectCoordinate::new(0, 0, 0),
-        heading: Heading::from_degrees(0.0),
+        heading: ObjectHeading::from_degrees(0.0),
         colour: 1,
         mapping: 1,
         floating: true,
@@ -64,7 +64,7 @@ fn test_armco1_floating() {
 fn test_armco1_flags_conversion() {
     let armco = armco::Armco {
         xyz: ObjectCoordinate::new(0, 0, 0),
-        heading: Heading::from_degrees(0.0),
+        heading: ObjectHeading::from_degrees(0.0),
         colour: 3,
         mapping: 5,
         floating: true,
@@ -83,7 +83,7 @@ fn test_armco1_flags_conversion() {
 fn test_armco1_colour_boundary() {
     let armco = armco::Armco {
         xyz: ObjectCoordinate::new(0, 0, 0),
-        heading: Heading::from_degrees(0.0),
+        heading: ObjectHeading::from_degrees(0.0),
         colour: 7, // Max 3-bit value
         mapping: 0,
         floating: false,
@@ -96,7 +96,7 @@ fn test_armco1_colour_boundary() {
 fn test_armco1_mapping_boundary() {
     let armco = armco::Armco {
         xyz: ObjectCoordinate::new(0, 0, 0),
-        heading: Heading::from_degrees(0.0),
+        heading: ObjectHeading::from_degrees(0.0),
         colour: 0,
         mapping: 15, // Max 4-bit value
         floating: false,
@@ -108,7 +108,7 @@ fn test_armco1_mapping_boundary() {
 #[test]
 fn test_chalk_basic_creation() {
     let coord = ObjectCoordinate::new(150, 250, 30);
-    let heading = Heading::from_degrees(90.0);
+    let heading = ObjectHeading::from_degrees(90.0);
     let chalk = chalk::Chalk {
         xyz: coord,
         colour: chalk::ChalkColour::Red,
@@ -135,7 +135,7 @@ fn test_chalk_all_colours() {
         let chalk = chalk::Chalk {
             xyz: ObjectCoordinate::new(0, 0, 0),
             colour,
-            heading: Heading::from_degrees(0.0),
+            heading: ObjectHeading::from_degrees(0.0),
             floating: false,
         };
         assert_eq!(chalk.colour, colour);
@@ -147,7 +147,7 @@ fn test_chalk_colour_conversion() {
     let chalk_white = chalk::Chalk {
         xyz: ObjectCoordinate::new(0, 0, 0),
         colour: chalk::ChalkColour::White,
-        heading: Heading::from_degrees(0.0),
+        heading: ObjectHeading::from_degrees(0.0),
         floating: false,
     };
 
@@ -160,7 +160,7 @@ fn test_chalk_floating_flag() {
     let chalk = chalk::Chalk {
         xyz: ObjectCoordinate::new(0, 0, 0),
         colour: chalk::ChalkColour::Blue,
-        heading: Heading::from_degrees(0.0),
+        heading: ObjectHeading::from_degrees(0.0),
         floating: true,
     };
 
@@ -171,7 +171,7 @@ fn test_chalk_floating_flag() {
 #[test]
 fn test_chalk_from_flags() {
     let flags = raw_flags(0x82); // floating + colour 2 (blue)
-    let heading = Heading::from_degrees(45.0);
+    let heading = ObjectHeading::from_degrees(45.0);
     let result = chalk::Chalk::new(raw_with(
         ObjectCoordinate::new(100, 100, 10),
         flags.flags,
@@ -189,7 +189,7 @@ fn test_insim_checkpoint_finish() {
     let checkpoint = insim::InsimCheckpoint {
         xyz: ObjectCoordinate::new(500, 500, 0),
         kind: insim::InsimCheckpointKind::Finish,
-        heading: Heading::from_degrees(0.0),
+        heading: ObjectHeading::from_degrees(0.0),
         floating: false,
     };
 
@@ -209,7 +209,7 @@ fn test_insim_checkpoint_all_kinds() {
         let checkpoint = insim::InsimCheckpoint {
             xyz: ObjectCoordinate::new(0, 0, 0),
             kind,
-            heading: Heading::from_degrees(0.0),
+            heading: ObjectHeading::from_degrees(0.0),
             floating: false,
         };
         assert_eq!(checkpoint.kind, kind);
@@ -221,7 +221,7 @@ fn test_insim_checkpoint_floating() {
     let checkpoint = insim::InsimCheckpoint {
         xyz: ObjectCoordinate::new(0, 0, 0),
         kind: insim::InsimCheckpointKind::Checkpoint1,
-        heading: Heading::from_degrees(0.0),
+        heading: ObjectHeading::from_degrees(0.0),
         floating: true,
     };
 
@@ -233,7 +233,7 @@ fn test_insim_checkpoint_floating() {
 #[test]
 fn test_insim_checkpoint_from_flags() {
     let flags = raw_flags(0x82); // floating + kind checkpoint2
-    let heading = Heading::from_degrees(90.0);
+    let heading = ObjectHeading::from_degrees(90.0);
     let result = insim::InsimCheckpoint::new(raw_with(
         ObjectCoordinate::new(200, 300, 5),
         flags.flags,
@@ -307,7 +307,7 @@ fn test_paint_letters_basic() {
         xyz: ObjectCoordinate::new(300, 400, 20),
         colour: painted::PaintColour::White,
         character: painted::Character::A,
-        heading: Heading::from_degrees(0.0),
+        heading: ObjectHeading::from_degrees(0.0),
         floating: false,
     };
 
@@ -330,7 +330,7 @@ fn test_paint_letters_various_characters() {
             xyz: ObjectCoordinate::new(0, 0, 0),
             colour: painted::PaintColour::White,
             character,
-            heading: Heading::from_degrees(0.0),
+            heading: ObjectHeading::from_degrees(0.0),
             floating: false,
         };
         assert_eq!(letters.character, character);
@@ -346,7 +346,7 @@ fn test_paint_letters_colours() {
             xyz: ObjectCoordinate::new(0, 0, 0),
             colour,
             character: painted::Character::A,
-            heading: Heading::from_degrees(0.0),
+            heading: ObjectHeading::from_degrees(0.0),
             floating: false,
         };
         assert_eq!(letters.colour, colour);
@@ -370,7 +370,7 @@ fn test_paint_letters_floating() {
         xyz: ObjectCoordinate::new(0, 0, 0),
         colour: painted::PaintColour::Yellow,
         character: painted::Character::B,
-        heading: Heading::from_degrees(45.0),
+        heading: ObjectHeading::from_degrees(45.0),
         floating: true,
     };
 
@@ -382,7 +382,7 @@ fn test_letterboard_rb_basic() {
     let board = letterboard_rb::LetterboardRB {
         xyz: ObjectCoordinate::new(600, 700, 40),
         colour: letterboard_rb::LetterboardRBColour::Red,
-        heading: Heading::from_degrees(0.0),
+        heading: ObjectHeading::from_degrees(0.0),
         character: letterboard_rb::Character::A,
         floating: false,
     };
@@ -396,7 +396,7 @@ fn test_letterboard_rb_colours() {
     let board_red = letterboard_rb::LetterboardRB {
         xyz: ObjectCoordinate::new(0, 0, 0),
         colour: letterboard_rb::LetterboardRBColour::Red,
-        heading: Heading::from_degrees(0.0),
+        heading: ObjectHeading::from_degrees(0.0),
         character: letterboard_rb::Character::A,
         floating: false,
     };
@@ -404,7 +404,7 @@ fn test_letterboard_rb_colours() {
     let board_blue = letterboard_rb::LetterboardRB {
         xyz: ObjectCoordinate::new(0, 0, 0),
         colour: letterboard_rb::LetterboardRBColour::Blue,
-        heading: Heading::from_degrees(0.0),
+        heading: ObjectHeading::from_degrees(0.0),
         character: letterboard_rb::Character::A,
         floating: false,
     };
@@ -418,7 +418,7 @@ fn test_letterboard_rb_blank_character() {
     let board = letterboard_rb::LetterboardRB {
         xyz: ObjectCoordinate::new(0, 0, 0),
         colour: letterboard_rb::LetterboardRBColour::Red,
-        heading: Heading::from_degrees(0.0),
+        heading: ObjectHeading::from_degrees(0.0),
         character: letterboard_rb::Character::Blank,
         floating: false,
     };
@@ -433,7 +433,7 @@ fn test_letterboard_rb_floating() {
     let board = letterboard_rb::LetterboardRB {
         xyz: ObjectCoordinate::new(0, 0, 0),
         colour: letterboard_rb::LetterboardRBColour::Blue,
-        heading: Heading::from_degrees(90.0),
+        heading: ObjectHeading::from_degrees(90.0),
         character: letterboard_rb::Character::Z,
         floating: true,
     };
@@ -446,7 +446,7 @@ fn test_letterboard_rb_floating() {
 #[test]
 fn test_letterboard_rb_from_flags() {
     let flags = raw_flags(0x81); // floating + colour blue + character A
-    let heading = Heading::from_degrees(0.0);
+    let heading = ObjectHeading::from_degrees(0.0);
     let result = letterboard_rb::LetterboardRB::new(raw_with(
         ObjectCoordinate::new(0, 0, 0),
         flags.flags,
@@ -464,7 +464,7 @@ fn test_tyre_stack2_basic() {
     let tyre = tyres::Tyres {
         xyz: ObjectCoordinate::new(200, 300, 0),
         colour: tyres::TyreColour::Black,
-        heading: Heading::from_degrees(0.0),
+        heading: ObjectHeading::from_degrees(0.0),
         floating: false,
     };
 
@@ -486,7 +486,7 @@ fn test_tyre_stack2_all_colours() {
         let tyre = tyres::Tyres {
             xyz: ObjectCoordinate::new(0, 0, 0),
             colour,
-            heading: Heading::from_degrees(0.0),
+            heading: ObjectHeading::from_degrees(0.0),
             floating: false,
         };
         assert_eq!(tyre.colour, colour);
@@ -498,7 +498,7 @@ fn test_tyre_stack2_flags_conversion() {
     let tyre = tyres::Tyres {
         xyz: ObjectCoordinate::new(0, 0, 0),
         colour: tyres::TyreColour::Red,
-        heading: Heading::from_degrees(0.0),
+        heading: ObjectHeading::from_degrees(0.0),
         floating: false,
     };
 
@@ -511,7 +511,7 @@ fn test_tyre_stack2_floating() {
     let tyre = tyres::Tyres {
         xyz: ObjectCoordinate::new(100, 100, 0),
         colour: tyres::TyreColour::Yellow,
-        heading: Heading::from_degrees(45.0),
+        heading: ObjectHeading::from_degrees(45.0),
         floating: true,
     };
 
@@ -523,7 +523,7 @@ fn test_tyre_stack2_floating() {
 #[test]
 fn test_tyre_stack2_from_flags() {
     let flags = raw_flags(0x83); // floating + colour green (4)
-    let heading = Heading::from_degrees(180.0);
+    let heading = ObjectHeading::from_degrees(180.0);
     let result = tyres::Tyres::new(raw_with(
         ObjectCoordinate::new(50, 50, 0),
         flags.flags,
@@ -539,7 +539,7 @@ fn test_tyre_stack2_from_flags() {
 fn test_post_basic() {
     let post = post::Post {
         xyz: ObjectCoordinate::new(400, 500, 100),
-        heading: Heading::from_degrees(0.0),
+        heading: ObjectHeading::from_degrees(0.0),
         colour: post::PostColour::Green,
         mapping: 1,
         floating: false,
@@ -564,7 +564,7 @@ fn test_post_all_colours() {
     for colour in colours {
         let post = post::Post {
             xyz: ObjectCoordinate::new(0, 0, 0),
-            heading: Heading::from_degrees(0.0),
+            heading: ObjectHeading::from_degrees(0.0),
             colour,
             mapping: 0,
             floating: false,
@@ -578,7 +578,7 @@ fn test_post_mapping_range() {
     for mapping in 0u8..=15 {
         let post = post::Post {
             xyz: ObjectCoordinate::new(0, 0, 0),
-            heading: Heading::from_degrees(0.0),
+            heading: ObjectHeading::from_degrees(0.0),
             colour: post::PostColour::Red,
             mapping,
             floating: false,
@@ -591,7 +591,7 @@ fn test_post_mapping_range() {
 fn test_post_floating() {
     let post = post::Post {
         xyz: ObjectCoordinate::new(0, 0, 0),
-        heading: Heading::from_degrees(0.0),
+        heading: ObjectHeading::from_degrees(0.0),
         colour: post::PostColour::Blue,
         mapping: 5,
         floating: true,
@@ -605,7 +605,7 @@ fn test_post_floating() {
 #[test]
 fn test_post_from_flags() {
     let flags = raw_flags(0x8A); // floating + colour 2 (red) + mapping 1
-    let heading = Heading::from_degrees(270.0);
+    let heading = ObjectHeading::from_degrees(270.0);
     let result = post::Post::new(raw_with(
         ObjectCoordinate::new(0, 0, 0),
         flags.flags,
@@ -623,7 +623,7 @@ fn test_post_from_flags() {
 fn test_start_lights_basic() {
     let lights = start_lights::StartLights {
         xyz: ObjectCoordinate::new(0, 0, 200),
-        heading: Heading::from_degrees(0.0),
+        heading: ObjectHeading::from_degrees(0.0),
         identifier: 0,
         floating: false,
     };
@@ -636,7 +636,7 @@ fn test_start_lights_identifier_range() {
     for id in 0u8..=63 {
         let lights = start_lights::StartLights {
             xyz: ObjectCoordinate::new(0, 0, 0),
-            heading: Heading::from_degrees(0.0),
+            heading: ObjectHeading::from_degrees(0.0),
             identifier: id,
             floating: false,
         };
@@ -648,7 +648,7 @@ fn test_start_lights_identifier_range() {
 fn test_start_lights_flags_conversion() {
     let lights = start_lights::StartLights {
         xyz: ObjectCoordinate::new(0, 0, 0),
-        heading: Heading::from_degrees(0.0),
+        heading: ObjectHeading::from_degrees(0.0),
         identifier: 42,
         floating: false,
     };
@@ -661,7 +661,7 @@ fn test_start_lights_flags_conversion() {
 fn test_start_lights_floating() {
     let lights = start_lights::StartLights {
         xyz: ObjectCoordinate::new(100, 100, 150),
-        heading: Heading::from_degrees(90.0),
+        heading: ObjectHeading::from_degrees(90.0),
         identifier: 15,
         floating: true,
     };
@@ -674,7 +674,7 @@ fn test_start_lights_floating() {
 #[test]
 fn test_start_lights_from_flags() {
     let flags = raw_flags(0xAA); // floating + identifier 42 (0x2A)
-    let heading = Heading::from_degrees(45.0);
+    let heading = ObjectHeading::from_degrees(45.0);
     let result = start_lights::StartLights::new(raw_with(
         ObjectCoordinate::new(0, 0, 0),
         flags.flags,
@@ -691,7 +691,7 @@ fn test_start_lights_from_flags() {
 fn test_vehicle_van_basic() {
     let van = vehicle_van::VehicleVan {
         xyz: ObjectCoordinate::new(800, 900, 50),
-        heading: Heading::from_degrees(0.0),
+        heading: ObjectHeading::from_degrees(0.0),
         colour: vehicle_van::VehicleVanColour::White,
         mapping: 2,
         floating: false,
@@ -716,7 +716,7 @@ fn test_vehicle_van_all_colours() {
     for colour in colours {
         let van = vehicle_van::VehicleVan {
             xyz: ObjectCoordinate::new(0, 0, 0),
-            heading: Heading::from_degrees(0.0),
+            heading: ObjectHeading::from_degrees(0.0),
             colour,
             mapping: 0,
             floating: false,
@@ -730,7 +730,7 @@ fn test_vehicle_van_mapping_range() {
     for mapping in 0u8..=15 {
         let van = vehicle_van::VehicleVan {
             xyz: ObjectCoordinate::new(0, 0, 0),
-            heading: Heading::from_degrees(0.0),
+            heading: ObjectHeading::from_degrees(0.0),
             colour: vehicle_van::VehicleVanColour::Blue,
             mapping,
             floating: false,
@@ -743,7 +743,7 @@ fn test_vehicle_van_mapping_range() {
 fn test_vehicle_van_floating() {
     let van = vehicle_van::VehicleVan {
         xyz: ObjectCoordinate::new(0, 0, 0),
-        heading: Heading::from_degrees(180.0),
+        heading: ObjectHeading::from_degrees(180.0),
         colour: vehicle_van::VehicleVanColour::Red,
         mapping: 7,
         floating: true,
@@ -757,7 +757,7 @@ fn test_vehicle_van_floating() {
 #[test]
 fn test_vehicle_van_from_flags() {
     let flags = raw_flags(0x89); // floating + colour 1 (red) + mapping 1
-    let heading = Heading::from_degrees(315.0);
+    let heading = ObjectHeading::from_degrees(315.0);
     let result = vehicle_van::VehicleVan::new(raw_with(
         ObjectCoordinate::new(0, 0, 0),
         flags.flags,

--- a/insim_core/src/object/tyres.rs
+++ b/insim_core/src/object/tyres.rs
@@ -1,7 +1,7 @@
 //! Tyre single object
 use crate::{
     DecodeError,
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -49,8 +49,8 @@ pub struct Tyres {
     pub xyz: ObjectCoordinate,
     /// Colour
     pub colour: TyreColour,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Floating
     pub floating: bool,
 }
@@ -58,7 +58,7 @@ pub struct Tyres {
 impl Tyres {
     pub(super) fn new(raw: Raw) -> Result<Self, DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = TyreColour::from(raw.raw_colour());
         let floating = raw.raw_floating();
         Ok(Self {
@@ -78,11 +78,11 @@ impl ObjectInfoInner for Tyres {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -95,6 +95,6 @@ impl ObjectInfoInner for Tyres {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/vehicle_ambulance.rs
+++ b/insim_core/src/object/vehicle_ambulance.rs
@@ -1,7 +1,7 @@
 //! Vehicle Ambulance object
 use crate::{
     DecodeError,
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -12,8 +12,8 @@ use crate::{
 pub struct VehicleAmbulance {
     /// Position
     pub xyz: ObjectCoordinate,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Colour (3 bits, 0-7)
     pub colour: u8,
     /// Mapping (4 bits, 0-15)
@@ -25,7 +25,7 @@ pub struct VehicleAmbulance {
 impl VehicleAmbulance {
     pub(super) fn new(raw: Raw) -> Result<Self, DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = raw.raw_colour();
         let mapping = raw.raw_mapping();
         let floating = raw.raw_floating();
@@ -48,11 +48,11 @@ impl ObjectInfoInner for VehicleAmbulance {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -65,6 +65,6 @@ impl ObjectInfoInner for VehicleAmbulance {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/vehicle_suv.rs
+++ b/insim_core/src/object/vehicle_suv.rs
@@ -1,7 +1,7 @@
 //! Vehicle SUV object
 use crate::{
     DecodeError,
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -48,8 +48,8 @@ impl From<u8> for VehicleSUVColour {
 pub struct VehicleSUV {
     /// Position
     pub xyz: ObjectCoordinate,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Colour (3 bits, 0-7)
     pub colour: VehicleSUVColour,
     /// Mapping (4 bits, 0-15)
@@ -61,7 +61,7 @@ pub struct VehicleSUV {
 impl VehicleSUV {
     pub(super) fn new(raw: Raw) -> Result<Self, DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = VehicleSUVColour::from(raw.raw_colour());
         let mapping = raw.raw_mapping();
         let floating = raw.raw_floating();
@@ -84,11 +84,11 @@ impl ObjectInfoInner for VehicleSUV {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -101,6 +101,6 @@ impl ObjectInfoInner for VehicleSUV {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/vehicle_truck.rs
+++ b/insim_core/src/object/vehicle_truck.rs
@@ -1,7 +1,7 @@
 //! Vehicle Truck object
 use crate::{
     DecodeError,
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -44,8 +44,8 @@ impl From<u8> for VehicleTruckColour {
 pub struct VehicleTruck {
     /// Position
     pub xyz: ObjectCoordinate,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Colour (3 bits, 0-7)
     pub colour: VehicleTruckColour,
     /// Mapping (4 bits, 0-15)
@@ -57,7 +57,7 @@ pub struct VehicleTruck {
 impl VehicleTruck {
     pub(super) fn new(raw: Raw) -> Result<Self, DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = VehicleTruckColour::from(raw.raw_colour());
         let mapping = raw.raw_mapping();
         let floating = raw.raw_floating();
@@ -80,11 +80,11 @@ impl ObjectInfoInner for VehicleTruck {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -97,6 +97,6 @@ impl ObjectInfoInner for VehicleTruck {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/object/vehicle_van.rs
+++ b/insim_core/src/object/vehicle_van.rs
@@ -1,7 +1,7 @@
 //! Vehicle Van object
 use crate::{
     DecodeError,
-    heading::Heading,
+    heading::ObjectHeading,
     object::{ObjectCoordinate, ObjectInfoInner, Raw},
 };
 
@@ -46,8 +46,8 @@ impl From<u8> for VehicleVanColour {
 pub struct VehicleVan {
     /// Position
     pub xyz: ObjectCoordinate,
-    /// Heading / Direction
-    pub heading: Heading,
+    /// ObjectHeading / Direction
+    pub heading: ObjectHeading,
     /// Colour (3 bits, 0-7)
     pub colour: VehicleVanColour,
     /// Mapping (4 bits, 0-15)
@@ -59,7 +59,7 @@ pub struct VehicleVan {
 impl VehicleVan {
     pub(super) fn new(raw: Raw) -> Result<Self, DecodeError> {
         let xyz = raw.xyz;
-        let heading = Heading::from_objectinfo_wire(raw.heading);
+        let heading = ObjectHeading::from_raw(raw.heading);
         let colour = VehicleVanColour::from(raw.raw_colour());
         let mapping = raw.raw_mapping();
         let floating = raw.raw_floating();
@@ -82,11 +82,11 @@ impl ObjectInfoInner for VehicleVan {
         flags
     }
 
-    fn heading_mut(&mut self) -> Option<&mut Heading> {
+    fn heading_mut(&mut self) -> Option<&mut ObjectHeading> {
         Some(&mut self.heading)
     }
 
-    fn heading(&self) -> Option<Heading> {
+    fn heading(&self) -> Option<ObjectHeading> {
         Some(self.heading)
     }
 
@@ -99,6 +99,6 @@ impl ObjectInfoInner for VehicleVan {
     }
 
     fn heading_objectinfo_wire(&self) -> u8 {
-        self.heading.to_objectinfo_wire()
+        self.heading.to_raw()
     }
 }

--- a/insim_core/src/speed.rs
+++ b/insim_core/src/speed.rs
@@ -44,6 +44,11 @@ impl SpeedF32 {
         Self(value)
     }
 
+    /// Consumes `self`, returning the inner value (metres per second).
+    pub const fn into_inner(self) -> f32 {
+        self.0
+    }
+
     /// Speed in metres per second.
     pub const fn to_metres_per_sec(self) -> f32 {
         self.0
@@ -125,6 +130,11 @@ impl SpeedU16 {
         Self((value * Self::UNITS_PER_MPS).round() as u16)
     }
 
+    /// Consumes `self`, returning the raw inner value (same as [`to_raw`](Self::to_raw)).
+    pub const fn into_inner(self) -> u16 {
+        self.0
+    }
+
     /// Speed in metres per second.
     pub fn to_metres_per_sec(self) -> f32 {
         self.0 as f32 / Self::UNITS_PER_MPS
@@ -200,6 +210,11 @@ impl SpeedU8 {
     /// Construct from metres per second (rounded and clamped to 0..=255).
     pub fn from_metres_per_sec(value: f32) -> Self {
         Self(value.round().clamp(0.0, u8::MAX as f32) as u8)
+    }
+
+    /// Consumes `self`, returning the raw inner value (same as [`to_raw`](Self::to_raw)).
+    pub const fn into_inner(self) -> u8 {
+        self.0
     }
 
     /// Speed in metres per second.
@@ -282,6 +297,12 @@ impl ClosingSpeed {
     /// Construct from metres per second (rounded to the nearest wire unit).
     pub fn from_metres_per_sec(value: f32) -> Self {
         Self::from_raw((value * Self::UNITS_PER_MPS).round() as u16)
+    }
+
+    /// Consumes `self`, returning the raw (masked, 12-bit) inner value (same as
+    /// [`to_raw`](Self::to_raw)).
+    pub const fn into_inner(self) -> u16 {
+        self.0
     }
 
     /// Closing speed in metres per second.

--- a/insim_core/src/speed.rs
+++ b/insim_core/src/speed.rs
@@ -40,6 +40,7 @@ impl SpeedF32 {
     pub const ZERO: Self = Self(0.0);
 
     /// Construct from metres per second.
+    #[doc(alias = "from_meters_per_sec")]
     pub const fn from_metres_per_sec(value: f32) -> Self {
         Self(value)
     }
@@ -50,16 +51,19 @@ impl SpeedF32 {
     }
 
     /// Speed in metres per second.
+    #[doc(alias = "to_meters_per_sec")]
     pub const fn to_metres_per_sec(self) -> f32 {
         self.0
     }
 
     /// Construct from kilometres per hour.
+    #[doc(alias = "from_kilometers_per_hour")]
     pub fn from_kilometres_per_hour(value: f32) -> Self {
         Self(value * MPS_PER_KMH)
     }
 
     /// Speed in kilometres per hour.
+    #[doc(alias = "to_kilometers_per_hour")]
     pub fn to_kilometres_per_hour(self) -> f32 {
         self.0 * 3.6
     }
@@ -126,6 +130,7 @@ impl SpeedU16 {
     }
 
     /// Construct from metres per second (rounded to the nearest wire unit).
+    #[doc(alias = "from_meters_per_sec")]
     pub fn from_metres_per_sec(value: f32) -> Self {
         Self((value * Self::UNITS_PER_MPS).round() as u16)
     }
@@ -136,16 +141,19 @@ impl SpeedU16 {
     }
 
     /// Speed in metres per second.
+    #[doc(alias = "to_meters_per_sec")]
     pub fn to_metres_per_sec(self) -> f32 {
         self.0 as f32 / Self::UNITS_PER_MPS
     }
 
     /// Construct from kilometres per hour.
+    #[doc(alias = "from_kilometers_per_hour")]
     pub fn from_kilometres_per_hour(value: f32) -> Self {
         Self::from_metres_per_sec(value * MPS_PER_KMH)
     }
 
     /// Speed in kilometres per hour.
+    #[doc(alias = "to_kilometers_per_hour")]
     pub fn to_kilometres_per_hour(self) -> f32 {
         self.to_metres_per_sec() * 3.6
     }
@@ -208,6 +216,7 @@ impl SpeedU8 {
     }
 
     /// Construct from metres per second (rounded and clamped to 0..=255).
+    #[doc(alias = "from_meters_per_sec")]
     pub fn from_metres_per_sec(value: f32) -> Self {
         Self(value.round().clamp(0.0, u8::MAX as f32) as u8)
     }
@@ -218,16 +227,19 @@ impl SpeedU8 {
     }
 
     /// Speed in metres per second.
+    #[doc(alias = "to_meters_per_sec")]
     pub fn to_metres_per_sec(self) -> f32 {
         self.0 as f32
     }
 
     /// Construct from kilometres per hour.
+    #[doc(alias = "from_kilometers_per_hour")]
     pub fn from_kilometres_per_hour(value: f32) -> Self {
         Self::from_metres_per_sec(value * MPS_PER_KMH)
     }
 
     /// Speed in kilometres per hour.
+    #[doc(alias = "to_kilometers_per_hour")]
     pub fn to_kilometres_per_hour(self) -> f32 {
         self.to_metres_per_sec() * 3.6
     }
@@ -295,6 +307,7 @@ impl ClosingSpeed {
     }
 
     /// Construct from metres per second (rounded to the nearest wire unit).
+    #[doc(alias = "from_meters_per_sec")]
     pub fn from_metres_per_sec(value: f32) -> Self {
         Self::from_raw((value * Self::UNITS_PER_MPS).round() as u16)
     }
@@ -306,16 +319,19 @@ impl ClosingSpeed {
     }
 
     /// Closing speed in metres per second.
+    #[doc(alias = "to_meters_per_sec")]
     pub fn to_metres_per_sec(self) -> f32 {
         self.0 as f32 / Self::UNITS_PER_MPS
     }
 
     /// Construct from kilometres per hour.
+    #[doc(alias = "from_kilometers_per_hour")]
     pub fn from_kilometres_per_hour(value: f32) -> Self {
         Self::from_metres_per_sec(value * MPS_PER_KMH)
     }
 
     /// Closing speed in kilometres per hour.
+    #[doc(alias = "to_kilometers_per_hour")]
     pub fn to_kilometres_per_hour(self) -> f32 {
         self.to_metres_per_sec() * 3.6
     }

--- a/insim_core/src/speed.rs
+++ b/insim_core/src/speed.rs
@@ -1,71 +1,336 @@
-//! Utilities for speed
+//! Speed wire types.
+//!
+//! LFS encodes speed in several different fixed-point scales depending on the
+//! packet. Rather than decode to a lossy floating-point "metres per second" and
+//! convert back (which is not idempotent on the wire), each wire encoding has its
+//! own newtype that stores the **raw integer** and exposes human-unit accessors on
+//! demand. Decoding then re-encoding always reproduces the original bytes exactly.
+//!
+//! | Type | Wire | Scale |
+//! |------|------|-------|
+//! | [`SpeedF32`] | `f32` | native metres per second (no scaling) |
+//! | [`SpeedU16`] | `u16` | 327.68 = 1 m/s (32768 = 100 m/s) |
+//! | [`SpeedU8`] | `u8` | 1 = 1 m/s |
+//! | [`ClosingSpeed`] | `u16` (top 4 bits reserved) | 10 = 1 m/s |
+
 use std::fmt;
 
-/// Speed stored as meters per second.
+use crate::{Decode, Encode};
+
+/// Conversion helpers shared by the speed newtypes.
+const MPS_PER_KMH: f32 = 1.0 / 3.6;
+const MPS_PER_MPH: f32 = 1.0 / 2.23694;
+
+/// Closing speed reserved-bit mask. The top 4 bits of the `spclose` field are
+/// reserved; only the low 12 bits carry the value.
+const CLOSING_SPEED_MASK: u16 = 0x0FFF;
+
+/// Speed transmitted as a native IEEE `f32` in metres per second (e.g. OutGauge).
 ///
-/// - Internal units are m/s.
-/// - Helper methods convert to and from kph and mph.
-#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
+/// Unlike the fixed-point wire types, there is no scaling here - the wire value is
+/// already an `f32` in m/s, so this wrapper is lossless. It exists for the unit
+/// conversions and type-safety; the stored value is metres per second.
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-pub struct Speed {
-    inner: f32,
-}
+pub struct SpeedF32(f32);
 
-impl Speed {
-    /// Zero m/s
-    pub const ZERO: Self = Self::from_meters_per_sec(0.0);
+impl SpeedF32 {
+    /// Zero speed.
+    pub const ZERO: Self = Self(0.0);
 
-    /// Consumes Speed, returning the raw wrapped value.
-    pub fn into_inner(self) -> f32 {
-        self.inner
+    /// Construct from metres per second.
+    pub const fn from_metres_per_sec(value: f32) -> Self {
+        Self(value)
     }
 
-    /// Convert from meters per sec
-    pub const fn from_meters_per_sec(value: f32) -> Self {
-        Self { inner: value }
-    }
-    /// Convert into meters per sec
-    pub const fn to_meters_per_sec(&self) -> f32 {
-        self.inner
+    /// Speed in metres per second.
+    pub const fn to_metres_per_sec(self) -> f32 {
+        self.0
     }
 
-    /// Convert from kph
-    pub const fn from_kilometers_per_hour(value: f32) -> Self {
-        Self { inner: value / 3.6 }
-    }
-    /// Convert into kph
-    pub const fn to_kilometers_per_hour(&self) -> f32 {
-        self.inner * 3.6
+    /// Construct from kilometres per hour.
+    pub fn from_kilometres_per_hour(value: f32) -> Self {
+        Self(value * MPS_PER_KMH)
     }
 
-    /// Convert from mph
-    pub const fn from_miles_per_hour(value: f32) -> Self {
-        Self {
-            inner: value / 2.23694,
-        }
+    /// Speed in kilometres per hour.
+    pub fn to_kilometres_per_hour(self) -> f32 {
+        self.0 * 3.6
     }
 
-    /// Convert into mph
-    pub const fn to_miles_per_hour(&self) -> f32 {
-        self.inner * 2.23694
+    /// Construct from miles per hour.
+    pub fn from_miles_per_hour(value: f32) -> Self {
+        Self(value * MPS_PER_MPH)
     }
 
-    /// Check if speed is zero.
-    pub const fn is_zero(&self) -> bool {
-        self.inner == 0.0
+    /// Speed in miles per hour.
+    pub fn to_miles_per_hour(self) -> f32 {
+        self.0 * 2.23694
+    }
+
+    /// Whether this is exactly zero.
+    pub fn is_zero(self) -> bool {
+        self.0 == 0.0
     }
 }
 
-impl fmt::Display for Speed {
+impl fmt::Display for SpeedF32 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:.2}m/s", self.inner)
+        write!(f, "{:.2}m/s", self.0)
     }
 }
 
-impl Default for Speed {
-    fn default() -> Self {
-        Self::ZERO
+impl Decode for SpeedF32 {
+    fn decode(ctx: &mut crate::DecodeContext) -> Result<Self, crate::DecodeError> {
+        Ok(Self(ctx.decode::<f32>("speed")?))
+    }
+}
+
+impl Encode for SpeedF32 {
+    fn encode(&self, ctx: &mut crate::EncodeContext) -> Result<(), crate::EncodeError> {
+        ctx.encode("speed", &self.0)
+    }
+}
+
+/// Speed as transmitted in [`Mci`](crate)'s `CompCar`: a `u16` where
+/// `327.68` units = 1 m/s (i.e. `32768` = 100 m/s).
+///
+/// Stores the raw wire value; conversions to m/s, km/h and mph are provided as
+/// accessors. Decoding then encoding reproduces the original `u16` exactly.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct SpeedU16(u16);
+
+impl SpeedU16 {
+    /// Zero speed.
+    pub const ZERO: Self = Self(0);
+
+    /// Raw wire units per metre/second.
+    const UNITS_PER_MPS: f32 = 327.68;
+
+    /// Construct from the raw wire value (lossless).
+    pub const fn from_raw(raw: u16) -> Self {
+        Self(raw)
+    }
+
+    /// The raw wire value (lossless).
+    pub const fn to_raw(self) -> u16 {
+        self.0
+    }
+
+    /// Construct from metres per second (rounded to the nearest wire unit).
+    pub fn from_metres_per_sec(value: f32) -> Self {
+        Self((value * Self::UNITS_PER_MPS).round() as u16)
+    }
+
+    /// Speed in metres per second.
+    pub fn to_metres_per_sec(self) -> f32 {
+        self.0 as f32 / Self::UNITS_PER_MPS
+    }
+
+    /// Construct from kilometres per hour.
+    pub fn from_kilometres_per_hour(value: f32) -> Self {
+        Self::from_metres_per_sec(value * MPS_PER_KMH)
+    }
+
+    /// Speed in kilometres per hour.
+    pub fn to_kilometres_per_hour(self) -> f32 {
+        self.to_metres_per_sec() * 3.6
+    }
+
+    /// Construct from miles per hour.
+    pub fn from_miles_per_hour(value: f32) -> Self {
+        Self::from_metres_per_sec(value * MPS_PER_MPH)
+    }
+
+    /// Speed in miles per hour.
+    pub fn to_miles_per_hour(self) -> f32 {
+        self.to_metres_per_sec() * 2.23694
+    }
+
+    /// Whether this is exactly zero.
+    pub const fn is_zero(self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl fmt::Display for SpeedU16 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:.2}m/s", self.to_metres_per_sec())
+    }
+}
+
+impl Decode for SpeedU16 {
+    fn decode(ctx: &mut crate::DecodeContext) -> Result<Self, crate::DecodeError> {
+        Ok(Self(ctx.decode::<u16>("speed")?))
+    }
+}
+
+impl Encode for SpeedU16 {
+    fn encode(&self, ctx: &mut crate::EncodeContext) -> Result<(), crate::EncodeError> {
+        ctx.encode("speed", &self.0)
+    }
+}
+
+/// Speed as transmitted in `CarContact`/`ConInfo`: a `u8` where 1 unit = 1 m/s.
+///
+/// Range is therefore 0..=255 m/s in whole-metre-per-second steps. Stores the raw
+/// wire value; decoding then encoding reproduces the original `u8` exactly.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct SpeedU8(u8);
+
+impl SpeedU8 {
+    /// Zero speed.
+    pub const ZERO: Self = Self(0);
+
+    /// Construct from the raw wire value (lossless).
+    pub const fn from_raw(raw: u8) -> Self {
+        Self(raw)
+    }
+
+    /// The raw wire value (lossless).
+    pub const fn to_raw(self) -> u8 {
+        self.0
+    }
+
+    /// Construct from metres per second (rounded and clamped to 0..=255).
+    pub fn from_metres_per_sec(value: f32) -> Self {
+        Self(value.round().clamp(0.0, u8::MAX as f32) as u8)
+    }
+
+    /// Speed in metres per second.
+    pub fn to_metres_per_sec(self) -> f32 {
+        self.0 as f32
+    }
+
+    /// Construct from kilometres per hour.
+    pub fn from_kilometres_per_hour(value: f32) -> Self {
+        Self::from_metres_per_sec(value * MPS_PER_KMH)
+    }
+
+    /// Speed in kilometres per hour.
+    pub fn to_kilometres_per_hour(self) -> f32 {
+        self.to_metres_per_sec() * 3.6
+    }
+
+    /// Construct from miles per hour.
+    pub fn from_miles_per_hour(value: f32) -> Self {
+        Self::from_metres_per_sec(value * MPS_PER_MPH)
+    }
+
+    /// Speed in miles per hour.
+    pub fn to_miles_per_hour(self) -> f32 {
+        self.to_metres_per_sec() * 2.23694
+    }
+
+    /// Whether this is exactly zero.
+    pub const fn is_zero(self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl fmt::Display for SpeedU8 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}m/s", self.0)
+    }
+}
+
+impl Decode for SpeedU8 {
+    fn decode(ctx: &mut crate::DecodeContext) -> Result<Self, crate::DecodeError> {
+        Ok(Self(ctx.decode::<u8>("speed")?))
+    }
+}
+
+impl Encode for SpeedU8 {
+    fn encode(&self, ctx: &mut crate::EncodeContext) -> Result<(), crate::EncodeError> {
+        ctx.encode("speed", &self.0)
+    }
+}
+
+/// Closing speed as transmitted in `Con`/`Obh` `spclose`: a `u16` where 10 units =
+/// 1 m/s. The top 4 bits of the wire field are reserved and are masked off on
+/// decode (and never written on encode).
+///
+/// Stores the raw (masked) wire value; decoding then encoding reproduces the
+/// original 12-bit value exactly.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct ClosingSpeed(u16);
+
+impl ClosingSpeed {
+    /// Zero closing speed.
+    pub const ZERO: Self = Self(0);
+
+    /// Raw wire units per metre/second.
+    const UNITS_PER_MPS: f32 = 10.0;
+
+    /// Construct from the raw wire value. The reserved top 4 bits are masked off.
+    pub const fn from_raw(raw: u16) -> Self {
+        Self(raw & CLOSING_SPEED_MASK)
+    }
+
+    /// The raw (masked, 12-bit) wire value.
+    pub const fn to_raw(self) -> u16 {
+        self.0
+    }
+
+    /// Construct from metres per second (rounded to the nearest wire unit).
+    pub fn from_metres_per_sec(value: f32) -> Self {
+        Self::from_raw((value * Self::UNITS_PER_MPS).round() as u16)
+    }
+
+    /// Closing speed in metres per second.
+    pub fn to_metres_per_sec(self) -> f32 {
+        self.0 as f32 / Self::UNITS_PER_MPS
+    }
+
+    /// Construct from kilometres per hour.
+    pub fn from_kilometres_per_hour(value: f32) -> Self {
+        Self::from_metres_per_sec(value * MPS_PER_KMH)
+    }
+
+    /// Closing speed in kilometres per hour.
+    pub fn to_kilometres_per_hour(self) -> f32 {
+        self.to_metres_per_sec() * 3.6
+    }
+
+    /// Construct from miles per hour.
+    pub fn from_miles_per_hour(value: f32) -> Self {
+        Self::from_metres_per_sec(value * MPS_PER_MPH)
+    }
+
+    /// Closing speed in miles per hour.
+    pub fn to_miles_per_hour(self) -> f32 {
+        self.to_metres_per_sec() * 2.23694
+    }
+
+    /// Whether this is exactly zero.
+    pub const fn is_zero(self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl fmt::Display for ClosingSpeed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:.2}m/s", self.to_metres_per_sec())
+    }
+}
+
+impl Decode for ClosingSpeed {
+    fn decode(ctx: &mut crate::DecodeContext) -> Result<Self, crate::DecodeError> {
+        Ok(Self::from_raw(ctx.decode::<u16>("spclose")?))
+    }
+}
+
+impl Encode for ClosingSpeed {
+    fn encode(&self, ctx: &mut crate::EncodeContext) -> Result<(), crate::EncodeError> {
+        // Defensive: the stored value is already masked, but never write reserved bits.
+        ctx.encode("spclose", &(self.0 & CLOSING_SPEED_MASK))
     }
 }
 
@@ -74,33 +339,64 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_mps() {
-        assert_eq!(Speed::from_meters_per_sec(100.0).to_meters_per_sec(), 100.0);
-
-        assert_eq!(Speed::from_meters_per_sec(100.0).into_inner(), 100.0);
+    fn test_speedu16_raw_roundtrip_exact() {
+        for raw in [0u16, 1, 327, 32768, 65535] {
+            assert_eq!(SpeedU16::from_raw(raw).to_raw(), raw);
+        }
     }
 
     #[test]
-    fn test_kmph() {
-        assert_eq!(
-            Speed::from_kilometers_per_hour(100.0).into_inner(),
-            27.777779
-        );
+    fn test_speedu16_mps() {
+        // 32768 = 100 m/s
+        assert_eq!(SpeedU16::from_raw(32768).to_metres_per_sec(), 100.0);
+        // round-trip through m/s lands back on the nearest raw unit
+        assert_eq!(SpeedU16::from_metres_per_sec(100.0).to_raw(), 32768);
     }
 
     #[test]
-    fn test_mph_kmph() {
-        assert_eq!(
-            Speed::from_kilometers_per_hour(100.0).to_miles_per_hour(),
-            62.137222
-        );
+    fn test_speedu16_kmph_mph() {
+        let s = SpeedU16::from_kilometres_per_hour(100.0);
+        assert!((s.to_kilometres_per_hour() - 100.0).abs() < 0.05);
+        let s = SpeedU16::from_miles_per_hour(60.0);
+        assert!((s.to_miles_per_hour() - 60.0).abs() < 0.05);
     }
 
     #[test]
-    fn test_is_zero() {
-        assert!(Speed::ZERO.is_zero());
-        assert!(Speed::from_meters_per_sec(0.0).is_zero());
-        assert!(!Speed::from_meters_per_sec(0.1).is_zero());
-        assert!(!Speed::from_meters_per_sec(100.0).is_zero());
+    fn test_speedu8_raw_roundtrip_exact() {
+        for raw in [0u8, 1, 100, 255] {
+            assert_eq!(SpeedU8::from_raw(raw).to_raw(), raw);
+        }
+    }
+
+    #[test]
+    fn test_speedu8_clamps() {
+        assert_eq!(SpeedU8::from_metres_per_sec(300.0).to_raw(), 255);
+        assert_eq!(SpeedU8::from_metres_per_sec(-5.0).to_raw(), 0);
+        assert_eq!(SpeedU8::from_metres_per_sec(42.0).to_raw(), 42);
+    }
+
+    #[test]
+    fn test_closing_speed_strips_reserved_bits() {
+        // 61441 = 0xF001 -> 0x0001
+        assert_eq!(ClosingSpeed::from_raw(61441).to_raw(), 1);
+        // 63495 = 0xF807 -> 0x0807 = 2055
+        assert_eq!(ClosingSpeed::from_raw(63495).to_raw(), 2055);
+    }
+
+    #[test]
+    fn test_closing_speed_mps() {
+        // 10 units = 1 m/s
+        assert_eq!(ClosingSpeed::from_raw(23).to_metres_per_sec(), 2.3);
+        assert_eq!(ClosingSpeed::from_metres_per_sec(2.3).to_raw(), 23);
+    }
+
+    #[test]
+    fn test_is_zero_and_default() {
+        assert!(SpeedU16::ZERO.is_zero());
+        assert!(SpeedU8::ZERO.is_zero());
+        assert!(ClosingSpeed::ZERO.is_zero());
+        assert_eq!(SpeedU16::default(), SpeedU16::ZERO);
+        assert_eq!(SpeedU8::default(), SpeedU8::ZERO);
+        assert_eq!(ClosingSpeed::default(), ClosingSpeed::ZERO);
     }
 }

--- a/insim_core/src/string/colours.rs
+++ b/insim_core/src/string/colours.rs
@@ -138,7 +138,7 @@ pub fn spans(input: &str) -> impl Iterator<Item = (u8, &str)> + '_ {
                     let _ = iter.next();
                 },
 
-                // ^n (color code)
+                // ^n (colour code)
                 Some(&(next_idx, next)) if next.is_lfs_colour() => {
                     let chunk = &input[chunk_start..idx];
                     let yielded_colour = current_colour;
@@ -146,7 +146,7 @@ pub fn spans(input: &str) -> impl Iterator<Item = (u8, &str)> + '_ {
                     // update state for the *next* iteration
                     current_colour = next.to_digit(10).unwrap_or(0) as u8;
                     chunk_start = next_idx + next.len_utf8();
-                    let _ = iter.next(); // consume the color digit
+                    let _ = iter.next(); // consume the colour digit
 
                     // only yield if there is actual text (skips empty chunks like ^1^2)
                     if !chunk.is_empty() {

--- a/insim_o3/insim_schema.json
+++ b/insim_o3/insim_schema.json
@@ -1523,18 +1523,12 @@
         "showlights"
       ]
     },
-    "AngVel": {
-      "description": "Angular velocity stored as radians per second (f32).\n\n- `from_wire_i16` / `to_wire_i16` use the LFS scaling (16384 = 360°/s).\n- Positive values indicate clockwise rotation when viewed from above.\n- Stored as `f32` radians/sec for consistency with [`Heading`](crate::heading::Heading)\n  and [`Speed`](crate::speed::Speed).",
-      "type": "object",
-      "properties": {
-        "radians_per_sec": {
-          "type": "number",
-          "format": "float"
-        }
-      },
-      "required": [
-        "radians_per_sec"
-      ]
+    "AngVelI16": {
+      "description": "Angular velocity as transmitted in `CompCar` (MCI): a signed `i16` where\n16384 = 360°/s.\n\nStores the raw wire value; conversions to degrees/radians per second are\naccessors. Decoding then encoding reproduces the original `i16` exactly.",
+      "type": "integer",
+      "format": "int16",
+      "maximum": 32767,
+      "minimum": -32768
     },
     "Armco": {
       "description": "Armco 1-5 barrier",
@@ -1552,8 +1546,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "mapping": {
           "description": "Mapping (4 bits, 0-15)",
@@ -1605,8 +1599,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "xyz": {
           "description": "Position",
@@ -1727,8 +1721,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "mapping": {
           "description": "Mapping (4 bits, 0-15)",
@@ -1763,8 +1757,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "mapping": {
           "description": "Mapping (4 bits, 0-15)",
@@ -1814,8 +1808,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "mapping": {
           "description": "Mapping (4 bits, 0-15)",
@@ -1916,8 +1910,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "mapping": {
           "description": "Mapping (4 bits, 0-15)",
@@ -1964,8 +1958,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "mapping": {
           "description": "Mapping (4 bits, 0-15)",
@@ -2312,15 +2306,15 @@
       "properties": {
         "direction": {
           "description": "Direction of motion.",
-          "$ref": "#/$defs/Heading"
+          "$ref": "#/$defs/HeadingU8"
         },
         "heading": {
           "description": "Car facing direction.",
-          "$ref": "#/$defs/Heading"
+          "$ref": "#/$defs/HeadingU8"
         },
         "speed": {
           "description": "Speed.",
-          "$ref": "#/$defs/Speed"
+          "$ref": "#/$defs/SpeedU8"
         },
         "x": {
           "description": "X position.",
@@ -2404,8 +2398,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "xyz": {
           "description": "Position",
@@ -2551,8 +2545,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "xyz": {
           "description": "Position",
@@ -2797,6 +2791,13 @@
       "maximum": 255,
       "minimum": 0
     },
+    "ClosingSpeed": {
+      "description": "Closing speed as transmitted in `Con`/`Obh` `spclose`: a `u16` where 10 units =\n1 m/s. The top 4 bits of the wire field are reserved and are masked off on\ndecode (and never written on encode).\n\nStores the raw (masked) wire value; decoding then encoding reproduces the\noriginal 12-bit value exactly.",
+      "type": "integer",
+      "format": "uint16",
+      "maximum": 65535,
+      "minimum": 0
+    },
     "Cnl": {
       "description": "Connection left notification.\n\n- Reports the reason and current connection count.",
       "type": "object",
@@ -2889,15 +2890,15 @@
       "properties": {
         "angvel": {
           "description": "Angular velocity of the car.",
-          "$ref": "#/$defs/AngVel"
+          "$ref": "#/$defs/AngVelI16"
         },
         "direction": {
           "description": "Direction of motion (heading of velocity).",
-          "$ref": "#/$defs/Heading"
+          "$ref": "#/$defs/HeadingU16"
         },
         "heading": {
           "description": "Car facing direction.",
-          "$ref": "#/$defs/Heading"
+          "$ref": "#/$defs/HeadingU16"
         },
         "info": {
           "description": "Additional state flags.",
@@ -2930,10 +2931,10 @@
         },
         "speed": {
           "description": "Speed.",
-          "$ref": "#/$defs/Speed"
+          "$ref": "#/$defs/SpeedU16"
         },
         "xyz": {
-          "description": "World position in meters.",
+          "description": "World position in metres.",
           "$ref": "#/$defs/Coordinate"
         }
       },
@@ -2987,7 +2988,7 @@
         },
         "spclose": {
           "description": "Closing speed at impact.",
-          "$ref": "#/$defs/Speed"
+          "$ref": "#/$defs/ClosingSpeed"
         },
         "time": {
           "description": "Time since session start, in milliseconds (wraps periodically).",
@@ -3009,18 +3010,18 @@
       "type": "object",
       "properties": {
         "accelf": {
-          "description": "Longitudinal acceleration.",
+          "description": "Longitudinal acceleration in m/s² (forward positive, braking negative).",
           "type": "integer",
-          "format": "uint8",
-          "maximum": 255,
-          "minimum": 0
+          "format": "int8",
+          "maximum": 127,
+          "minimum": -128
         },
         "accelr": {
-          "description": "Lateral acceleration.",
+          "description": "Lateral acceleration in m/s² (rightward positive, leftward negative).",
           "type": "integer",
-          "format": "uint8",
-          "maximum": 255,
-          "minimum": 0
+          "format": "int8",
+          "maximum": 127,
+          "minimum": -128
         },
         "brk": {
           "description": "Brake input (0-15).",
@@ -3038,7 +3039,7 @@
         },
         "direction": {
           "description": "Direction of motion.",
-          "$ref": "#/$defs/Heading"
+          "$ref": "#/$defs/HeadingU8"
         },
         "gearsp": {
           "description": "Gear selector (0-15).",
@@ -3056,7 +3057,7 @@
         },
         "heading": {
           "description": "Car facing direction.",
-          "$ref": "#/$defs/Heading"
+          "$ref": "#/$defs/HeadingU8"
         },
         "info": {
           "description": "Additional car state flags.",
@@ -3068,14 +3069,14 @@
         },
         "speed": {
           "description": "Speed.",
-          "$ref": "#/$defs/Speed"
+          "$ref": "#/$defs/SpeedU8"
         },
         "steer": {
-          "description": "Front wheel steering angle (right positive).",
+          "description": "Front wheel steering angle in degrees (right positive, left negative).",
           "type": "integer",
-          "format": "uint8",
-          "maximum": 255,
-          "minimum": 0
+          "format": "int8",
+          "maximum": 127,
+          "minimum": -128
         },
         "thr": {
           "description": "Throttle input (0-15).",
@@ -3176,8 +3177,8 @@
       "type": "object",
       "properties": {
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "height": {
           "description": "Height",
@@ -3231,8 +3232,8 @@
       "type": "object",
       "properties": {
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "height": {
           "description": "Height",
@@ -3268,8 +3269,8 @@
           "$ref": "#/$defs/ConcreteColour"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "height": {
           "description": "Height",
@@ -3301,8 +3302,8 @@
           "$ref": "#/$defs/ConcreteColour"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "pitch": {
           "description": "Pitch",
@@ -3330,8 +3331,8 @@
       "type": "object",
       "properties": {
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "length": {
           "description": "Length",
@@ -3367,8 +3368,8 @@
           "$ref": "#/$defs/ConcreteColour"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "length": {
           "description": "Length",
@@ -3400,8 +3401,8 @@
           "$ref": "#/$defs/ConcreteColour"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "height": {
           "description": "Height",
@@ -3437,8 +3438,8 @@
           "$ref": "#/$defs/ConcreteColour"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "length": {
           "description": "Length",
@@ -3480,8 +3481,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "xyz": {
           "description": "Position",
@@ -3551,8 +3552,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "kind": {
           "description": "Kind of Control Object",
@@ -3721,7 +3722,7 @@
         },
         "h": {
           "description": "heading - 0 points along Y axis",
-          "$ref": "#/$defs/Heading"
+          "$ref": "#/$defs/HeadingU16"
         },
         "ingamecam": {
           "description": "CameraView",
@@ -4175,18 +4176,19 @@
         "h_tres"
       ]
     },
-    "Heading": {
-      "description": "Angular measurement stored as radians (f64).\n\n- 0° points along world Y, 90° along world -X.\n- Values are not auto-normalized; use `normalize()` when needed.\n- Includes object-heading wire conversions.\n\nRepresents heading or direction in LFS game space. Internally stored as f64 radians\nfor consistency across the codebase, with convenient conversions to/from degrees.\nUses double precision to minimize cumulative errors in physics calculations and\nintegration over time.\n\n# Orientation\n- 0 = world Y direction** (forward/north)\n- 90 = world -X direction** (left/west)\n- 180 = -Y direction** (backward/south)\n- 270 = world X direction** (right/east)\n\nAngles increase in the anti-clockwise direction when viewed from above.\n\n# Wraparound\nAngles are **not** automatically normalized. A Heading created from 450 will\npreserve that value internally. Use [`normalize()`](Heading::normalize) to wrap\nangles to the 0->360 range if needed.\n\n```\nuse insim_core::heading::Heading;\n\nlet over = Heading::from_degrees(450.0);\nassert!((over.to_degrees() - 450.0).abs() < 0.0001);  // Preserved as-is\n\nlet normalized = over.normalize();\nassert!((normalized.to_degrees() - 90.0).abs() < 0.0001);  // Wrapped to [0, 360)\n```\n\n# Examples\n```\nuse insim_core::heading::Heading;\n\nlet forward = Heading::from_degrees(0.0);    // Y direction\nlet left = Heading::from_degrees(90.0);      // -X direction\nlet backward = Heading::from_degrees(180.0); // -Y direction\n\nassert_eq!(forward.to_degrees(), 0.0);\nassert_eq!(left.to_degrees(), 90.0);\n```",
-      "type": "object",
-      "properties": {
-        "radians": {
-          "type": "number",
-          "format": "double"
-        }
-      },
-      "required": [
-        "radians"
-      ]
+    "HeadingU16": {
+      "description": "Heading as transmitted in `CompCar` (MCI) and `Cpp`: a `u16` where\n32768 = 180°, zero at 0.\n\nStores the raw wire value; degree/radian conversions are accessors.\nDecoding then encoding reproduces the original value exactly.",
+      "type": "integer",
+      "format": "uint16",
+      "maximum": 65535,
+      "minimum": 0
+    },
+    "HeadingU8": {
+      "description": "Heading as transmitted in `CarContact`/`ConInfo`: a `u8` where\n128 = 180°, zero at 0.\n\nStores the raw wire value; degree/radian conversions are accessors.\nDecoding then encoding reproduces the original value exactly.",
+      "type": "integer",
+      "format": "uint8",
+      "maximum": 255,
+      "minimum": 0
     },
     "Hlv": {
       "description": "Hot lap validity violation report.\n\n- Sent when HLVC is enabled in [IsiFlags](crate::insim::IsiFlags).",
@@ -4285,8 +4287,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "kind": {
           "description": "Kind of checkpoint",
@@ -4565,7 +4567,7 @@
               "properties": {
                 "heading": {
                   "description": "Heading / Direction",
-                  "$ref": "#/$defs/Heading"
+                  "$ref": "#/$defs/ObjectHeading"
                 },
                 "xyz": {
                   "description": "Position",
@@ -4601,8 +4603,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "mapping": {
           "description": "Mapping",
@@ -4936,8 +4938,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "xyz": {
           "description": "Position",
@@ -4984,8 +4986,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "xyz": {
           "description": "Position",
@@ -5032,8 +5034,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "xyz": {
           "description": "Position",
@@ -5107,8 +5109,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "kind": {
           "description": "Kind of marker",
@@ -5157,8 +5159,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "kind": {
           "description": "Kind of distance marker",
@@ -5206,8 +5208,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "mapping": {
           "description": "Mapping (4 bits, 0-15)",
@@ -5238,8 +5240,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Flags: watching/left/right\nHeading",
-          "$ref": "#/$defs/Heading"
+          "description": "Flags: watching/left/right\nObjectHeading",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "kind": {
           "description": "Kind of Marshal",
@@ -5852,7 +5854,7 @@
         },
         "spclose": {
           "description": "Closing speed at impact.",
-          "$ref": "#/$defs/Speed"
+          "$ref": "#/$defs/ClosingSpeed"
         },
         "time": {
           "description": "Time since session start, in milliseconds (wraps periodically).",
@@ -5942,6 +5944,13 @@
         "y",
         "z"
       ]
+    },
+    "ObjectHeading": {
+      "description": "Heading as transmitted in layout `ObjectInfo`: a `u8` where 128 = 180°\n**and the zero-point is offset** so that raw 128 = 0°\n(`raw = (degrees + 180) * 256 / 360`). This is why it is a distinct type\nfrom [`HeadingU8`] despite the identical scale.\n\n- 128 = 0° (forward), 192 = 90°, 0 = 180°, 64 = 270°.\n\nStores the raw wire value; degree/radian conversions are accessors.\nDecoding then encoding reproduces the original value exactly.",
+      "type": "integer",
+      "format": "uint8",
+      "maximum": 255,
+      "minimum": 0
     },
     "ObjectInfo": {
       "description": "Layout Object",
@@ -7385,8 +7394,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "index": {
           "description": "Position index (0-47, representing start positions 1-48)",
@@ -7423,8 +7432,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "mapping": {
           "description": "Mapping (4 bits, 0-15)",
@@ -7870,8 +7879,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "mapping": {
           "description": "Mapping (4 bits, 0-15)",
@@ -8056,8 +8065,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "mapping": {
           "description": "Mapping (4 bits, 0-15)",
@@ -8095,8 +8104,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "mapping": {
           "description": "Mapping (4 bits, 0-15)",
@@ -8774,8 +8783,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "kind": {
           "description": "Kind",
@@ -8810,8 +8819,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "mapping": {
           "description": "Mapping",
@@ -9074,19 +9083,6 @@
         }
       ]
     },
-    "Speed": {
-      "description": "Speed stored as meters per second.\n\n- Internal units are m/s.\n- Helper methods convert to and from kph and mph.",
-      "type": "object",
-      "properties": {
-        "inner": {
-          "type": "number",
-          "format": "float"
-        }
-      },
-      "required": [
-        "inner"
-      ]
-    },
     "SpeedHump": {
       "description": "Speed hump 10m",
       "type": "object",
@@ -9103,8 +9099,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "mapping": {
           "description": "Mapping (4 bits, 0-15)",
@@ -9150,6 +9146,20 @@
           "const": "Speed40Mph"
         }
       ]
+    },
+    "SpeedU16": {
+      "description": "Speed as transmitted in [`Mci`](crate)'s `CompCar`: a `u16` where\n`327.68` units = 1 m/s (i.e. `32768` = 100 m/s).\n\nStores the raw wire value; conversions to m/s, km/h and mph are provided as\naccessors. Decoding then encoding reproduces the original `u16` exactly.",
+      "type": "integer",
+      "format": "uint16",
+      "maximum": 65535,
+      "minimum": 0
+    },
+    "SpeedU8": {
+      "description": "Speed as transmitted in `CarContact`/`ConInfo`: a `u8` where 1 unit = 1 m/s.\n\nRange is therefore 0..=255 m/s in whole-metre-per-second steps. Stores the raw\nwire value; decoding then encoding reproduces the original `u8` exactly.",
+      "type": "integer",
+      "format": "uint8",
+      "maximum": 255,
+      "minimum": 0
     },
     "Spx": {
       "description": "Split timing for a player.\n\n- Sent when a player crosses a split.",
@@ -9396,8 +9406,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "identifier": {
           "description": "identifier",
@@ -9427,8 +9437,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "index": {
           "description": "Position index (0-47, representing start positions 1-48)",
@@ -9854,8 +9864,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "xyz": {
           "description": "Position",
@@ -9973,8 +9983,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "mapping": {
           "description": "Mapping (4 bits, 0-15)",
@@ -10009,8 +10019,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "mapping": {
           "description": "Mapping (4 bits, 0-15)",
@@ -10512,8 +10522,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "mapping": {
           "description": "Mapping (4 bits, 0-15)",
@@ -10561,8 +10571,8 @@
           "type": "boolean"
         },
         "heading": {
-          "description": "Heading / Direction",
-          "$ref": "#/$defs/Heading"
+          "description": "ObjectHeading / Direction",
+          "$ref": "#/$defs/ObjectHeading"
         },
         "mapping": {
           "description": "Mapping (4 bits, 0-15)",

--- a/insim_o3/python/insim_o3/packets.py
+++ b/insim_o3/python/insim_o3/packets.py
@@ -236,18 +236,14 @@ type AiInputType = (
 )
 
 
-class AngVel(BaseModel):
-    """Angular velocity stored as radians per second (f32)."""
-
-    radians_per_sec: float
-
-
 class Armco(BaseModel):
     """Armco 1-5 barrier"""
 
     colour: Annotated[int, Field(description="Colour (3 bits, 0-7)", ge=0, le=255)]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     mapping: Annotated[int, Field(description="Mapping (4 bits, 0-15)", ge=0, le=255)]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -270,7 +266,9 @@ class Arrows(BaseModel):
     arrow: Annotated[Arrow, Field(description="Arrow")]
     colour: Annotated[PaintColour, Field(description="Colour")]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
 
@@ -279,7 +277,9 @@ class Bale(BaseModel):
 
     colour: Annotated[int, Field(description="Colour (3 bits, 0-7)", ge=0, le=255)]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     mapping: Annotated[int, Field(description="Mapping (4 bits, 0-15)", ge=0, le=255)]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -289,7 +289,9 @@ class Banner(BaseModel):
 
     colour: Annotated[BannerColour, Field(description="Colour (3 bits, 0-7)")]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     mapping: Annotated[int, Field(description="Mapping (4 bits, 0-15)", ge=0, le=255)]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -310,7 +312,9 @@ class Barrier(BaseModel):
 
     colour: Annotated[int, Field(description="Colour (3 bits, 0-7)", ge=0, le=255)]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     mapping: Annotated[int, Field(description="Mapping (4 bits, 0-15)", ge=0, le=255)]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -329,7 +333,9 @@ class Bin1(BaseModel):
 
     colour: Annotated[Bin1Colour, Field(description="Colour (3 bits, 0-7)")]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     mapping: Annotated[int, Field(description="Mapping (4 bits, 0-15)", ge=0, le=255)]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -350,7 +356,9 @@ class Bin2(BaseModel):
 
     colour: Annotated[Bin2Colour, Field(description="Colour (3 bits, 0-7)")]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     mapping: Annotated[int, Field(description="Mapping (4 bits, 0-15)", ge=0, le=255)]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -430,9 +438,9 @@ class CameraView(StrEnum):
 class CarContact(BaseModel):
     """Contact details used by collision reports."""
 
-    direction: Annotated[Heading, Field(description="Direction of motion.")]
-    heading: Annotated[Heading, Field(description="Car facing direction.")]
-    speed: Annotated[Speed, Field(description="Speed.")]
+    direction: Annotated[int, Field(description="Direction of motion.", ge=0, le=255)]
+    heading: Annotated[int, Field(description="Car facing direction.", ge=0, le=255)]
+    speed: Annotated[int, Field(description="Speed.", ge=0, le=255)]
     x: Annotated[int, Field(description="X position.", ge=-32768, le=32767)]
     y: Annotated[int, Field(description="Y position.", ge=-32768, le=32767)]
     z: Annotated[int, Field(description="Z position.", ge=0, le=255)]
@@ -450,7 +458,9 @@ class Chalk(BaseModel):
 
     colour: Annotated[ChalkColour, Field(description="Colour")]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
 
@@ -575,7 +585,9 @@ class Chevron(BaseModel):
 
     colour: Annotated[ChevronColour, Field(description="Colour")]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
 
@@ -682,11 +694,14 @@ class CnlReason(StrEnum):
 class CompCar(BaseModel):
     """Per-car telemetry entry used by [Mci]."""
 
-    angvel: Annotated[AngVel, Field(description="Angular velocity of the car.")]
-    direction: Annotated[
-        Heading, Field(description="Direction of motion (heading of velocity).")
+    angvel: Annotated[
+        int, Field(description="Angular velocity of the car.", ge=-32768, le=32767)
     ]
-    heading: Annotated[Heading, Field(description="Car facing direction.")]
+    direction: Annotated[
+        int,
+        Field(description="Direction of motion (heading of velocity).", ge=0, le=65535),
+    ]
+    heading: Annotated[int, Field(description="Car facing direction.", ge=0, le=65535)]
     info: Annotated[CompCarInfo, Field(description="Additional state flags.")]
     lap: Annotated[int, Field(description="Current lap number.", ge=0, le=65535)]
     node: Annotated[
@@ -695,8 +710,8 @@ class CompCar(BaseModel):
     ]
     plid: Annotated[int, Field(description="Player identifier.", ge=0, le=255)]
     position: Annotated[int, Field(description="Race position.", ge=0, le=255)]
-    speed: Annotated[Speed, Field(description="Speed.")]
-    xyz: Annotated[Coordinate, Field(description="World position in meters.")]
+    speed: Annotated[int, Field(description="Speed.", ge=0, le=65535)]
+    xyz: Annotated[Coordinate, Field(description="World position in metres.")]
 
 
 type CompCarInfo = list[CompCarInfoFlag]
@@ -716,21 +731,37 @@ class ConInfo(BaseModel):
     """Per-car contact details used in [Con]."""
 
     accelf: Annotated[
-        int, Field(description="Longitudinal acceleration.", ge=0, le=255)
+        int,
+        Field(
+            description="Longitudinal acceleration in m/s² (forward positive, braking negative).",
+            ge=-128,
+            le=127,
+        ),
     ]
-    accelr: Annotated[int, Field(description="Lateral acceleration.", ge=0, le=255)]
+    accelr: Annotated[
+        int,
+        Field(
+            description="Lateral acceleration in m/s² (rightward positive, leftward negative).",
+            ge=-128,
+            le=127,
+        ),
+    ]
     brk: Annotated[int, Field(description="Brake input (0-15).", ge=0, le=255)]
     clu: Annotated[int, Field(description="Clutch input (0-15).", ge=0, le=255)]
-    direction: Annotated[Heading, Field(description="Direction of motion.")]
+    direction: Annotated[int, Field(description="Direction of motion.", ge=0, le=255)]
     gearsp: Annotated[int, Field(description="Gear selector (0-15).", ge=0, le=255)]
     han: Annotated[int, Field(description="Handbrake input (0-15).", ge=0, le=255)]
-    heading: Annotated[Heading, Field(description="Car facing direction.")]
+    heading: Annotated[int, Field(description="Car facing direction.", ge=0, le=255)]
     info: Annotated[CompCarInfo, Field(description="Additional car state flags.")]
     plid: Annotated[int, Field(description="Player identifier.", ge=0, le=255)]
-    speed: Annotated[Speed, Field(description="Speed.")]
+    speed: Annotated[int, Field(description="Speed.", ge=0, le=255)]
     steer: Annotated[
         int,
-        Field(description="Front wheel steering angle (right positive).", ge=0, le=255),
+        Field(
+            description="Front wheel steering angle in degrees (right positive, left negative).",
+            ge=-128,
+            le=127,
+        ),
     ]
     thr: Annotated[int, Field(description="Throttle input (0-15).", ge=0, le=255)]
     x: Annotated[int, Field(description="X position.", ge=-32768, le=32767)]
@@ -791,7 +822,9 @@ class ConcreteHeight(StrEnum):
 class ConcretePillar(BaseModel):
     """Concrete Pillar"""
 
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     height: Annotated[ConcreteHeight, Field(description="Height")]
     x: Annotated[Size, Field(description="SizeX")]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
@@ -822,7 +855,9 @@ class ConcretePitch(StrEnum):
 class ConcreteRamp(BaseModel):
     """Concrete Ramp"""
 
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     height: Annotated[ConcreteHeight, Field(description="Height")]
     length: Annotated[ConcreteWidthLength, Field(description="Length")]
     width: Annotated[ConcreteWidthLength, Field(description="Width")]
@@ -833,7 +868,9 @@ class ConcreteRampWall(BaseModel):
     """Concrete Ramp Wall"""
 
     colour: Annotated[ConcreteColour, Field(description="Colour")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     height: Annotated[ConcreteHeight, Field(description="Height")]
     length: Annotated[ConcreteWidthLength, Field(description="Length")]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
@@ -843,7 +880,9 @@ class ConcreteShortSlabWall(BaseModel):
     """Concrete Short Slab Wall"""
 
     colour: Annotated[ConcreteColour, Field(description="Colour")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     pitch: Annotated[ConcretePitch, Field(description="Pitch")]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
     y: Annotated[Size, Field(description="Size Y")]
@@ -852,7 +891,9 @@ class ConcreteShortSlabWall(BaseModel):
 class ConcreteSlab(BaseModel):
     """Concrete Slab"""
 
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     length: Annotated[ConcreteWidthLength, Field(description="Length")]
     pitch: Annotated[ConcretePitch, Field(description="Pitch")]
     width: Annotated[ConcreteWidthLength, Field(description="Width")]
@@ -863,7 +904,9 @@ class ConcreteSlabWall(BaseModel):
     """Concrete Slab Wall"""
 
     colour: Annotated[ConcreteColour, Field(description="Colour")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     length: Annotated[ConcreteWidthLength, Field(description="Length")]
     pitch: Annotated[ConcretePitch, Field(description="Pitch")]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
@@ -873,7 +916,9 @@ class ConcreteWall(BaseModel):
     """Concrete Wall"""
 
     colour: Annotated[ConcreteColour, Field(description="Colour")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     height: Annotated[ConcreteHeight, Field(description="Height")]
     length: Annotated[ConcreteWidthLength, Field(description="Length")]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
@@ -884,7 +929,9 @@ class ConcreteWedge(BaseModel):
 
     angle: Annotated[ConcreteAngle, Field(description="Angle")]
     colour: Annotated[ConcreteColour, Field(description="Colour")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     length: Annotated[ConcreteWidthLength, Field(description="Length")]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -903,7 +950,9 @@ class Cone(BaseModel):
 
     colour: Annotated[ConeColour, Field(description="Colour")]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
 
@@ -923,7 +972,7 @@ class Control(BaseModel):
     """Control object"""
 
     floating: Annotated[bool, Field(description="Floating?")]
-    heading: Annotated[Heading, Field(description="Heading")]
+    heading: Annotated[int, Field(description="ObjectHeading", ge=0, le=255)]
     kind: Annotated[ControlKind, Field(description="Kind of Control Object")]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -1099,12 +1148,6 @@ class HcpCarHandicap(BaseModel):
     ]
 
 
-class Heading(BaseModel):
-    """Angular measurement stored as radians (f64)."""
-
-    radians: float
-
-
 class Hlvc(StrEnum):
     """Hot lap validity failure reason."""
 
@@ -1118,7 +1161,9 @@ class InsimCheckpoint(BaseModel):
     """InsimCheckpoint"""
 
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     kind: Annotated[InsimCheckpointKind, Field(description="Kind of checkpoint")]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -1173,7 +1218,7 @@ class JrrAction(StrEnum):
 
 
 class JrrStartPositionCustomPayload(BaseModel):
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[int, Field(description="Heading / Direction", ge=0, le=255)]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
 
@@ -1196,7 +1241,9 @@ class Kerb(BaseModel):
 
     colour: Annotated[int, Field(description="Colour (3 bits, 0-7)", ge=0, le=255)]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     mapping: Annotated[KerbColour, Field(description="Mapping")]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -1341,7 +1388,9 @@ class LetterboardRB(BaseModel):
     character: Annotated[Character2, Field(description="Mapping (6 bits, 0-63)")]
     colour: Annotated[LetterboardRBColour, Field(description="Colour")]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
 
@@ -1358,7 +1407,9 @@ class LetterboardWY(BaseModel):
     character: Annotated[Character2, Field(description="Mapping (6 bits, 0-63)")]
     colour: Annotated[LetterboardWYColour, Field(description="Colour")]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
 
@@ -1375,7 +1426,9 @@ class Letters(BaseModel):
     character: Annotated[Character, Field(description="Character")]
     colour: Annotated[PaintColour, Field(description="Colour")]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
 
@@ -1392,7 +1445,9 @@ class MarkerCorner(BaseModel):
     """Corner Marker"""
 
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     kind: Annotated[MarkerCornerKind, Field(description="Kind of marker")]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -1422,7 +1477,9 @@ class MarkerDistance(BaseModel):
     """Distance Marker"""
 
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     kind: Annotated[MarkerDistanceKind, Field(description="Kind of distance marker")]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -1445,7 +1502,9 @@ class Marquee(BaseModel):
 
     colour: Annotated[int, Field(description="Colour (3 bits, 0-7)", ge=0, le=255)]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     mapping: Annotated[int, Field(description="Mapping (4 bits, 0-15)", ge=0, le=255)]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -1455,7 +1514,8 @@ class Marshal(BaseModel):
 
     floating: Annotated[bool, Field(description="Floating?")]
     heading: Annotated[
-        Heading, Field(description="Flags: watching/left/right\nHeading")
+        int,
+        Field(description="Flags: watching/left/right\nObjectHeading", ge=0, le=255),
     ]
     kind: Annotated[MarshalKind, Field(description="Kind of Marshal")]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
@@ -2262,7 +2322,9 @@ class PitStartPoint(BaseModel):
     """Pit start point"""
 
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     index: Annotated[
         int,
         Field(
@@ -2279,7 +2341,9 @@ class PitStopBox(BaseModel):
 
     colour: Annotated[int, Field(description="Colour (3 bits, 0-7)", ge=0, le=255)]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     mapping: Annotated[int, Field(description="Mapping (4 bits, 0-15)", ge=0, le=255)]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -2461,7 +2525,9 @@ class Post(BaseModel):
 
     colour: Annotated[PostColour, Field(description="Colour (3 bits, 0-7)")]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     mapping: Annotated[int, Field(description="Mapping (4 bits, 0-15)", ge=0, le=255)]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -2541,7 +2607,9 @@ class Railing(BaseModel):
 
     colour: Annotated[int, Field(description="Colour (3 bits, 0-7)", ge=0, le=255)]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     mapping: Annotated[int, Field(description="Mapping (4 bits, 0-15)", ge=0, le=255)]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -2551,7 +2619,9 @@ class Ramp(BaseModel):
 
     colour: Annotated[int, Field(description="Colour (3 bits, 0-7)", ge=0, le=255)]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     mapping: Annotated[int, Field(description="Mapping (4 bits, 0-15)", ge=0, le=255)]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -2654,7 +2724,9 @@ class SignMetal(BaseModel):
 
     colour: Annotated[int, Field(description="Colour (3 bits, 0-7)", ge=0, le=255)]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     kind: Annotated[MetalSignKind, Field(description="Kind")]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -2664,7 +2736,9 @@ class SignSpeed(BaseModel):
 
     colour: Annotated[int, Field(description="Colour (3 bits, 0-7)", ge=0, le=255)]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     mapping: Annotated[SpeedSignMapping, Field(description="Mapping")]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -2782,18 +2856,14 @@ class SoundType(StrEnum):
     Error = "Error"
 
 
-class Speed(BaseModel):
-    """Speed stored as meters per second."""
-
-    inner: float
-
-
 class SpeedHump(BaseModel):
     """Speed hump 10m"""
 
     colour: Annotated[int, Field(description="Colour (3 bits, 0-7)", ge=0, le=255)]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     mapping: Annotated[int, Field(description="Mapping (4 bits, 0-15)", ge=0, le=255)]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -2842,7 +2912,9 @@ class StartLights(BaseModel):
     """StartLights"""
 
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     identifier: Annotated[int, Field(description="identifier", ge=0, le=255)]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -2851,7 +2923,9 @@ class StartPosition(BaseModel):
     """Start Position"""
 
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     index: Annotated[
         int,
         Field(
@@ -2947,7 +3021,9 @@ class Tyres(BaseModel):
 
     colour: Annotated[TyreColour, Field(description="Colour")]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
 
@@ -2968,7 +3044,9 @@ class VehicleAmbulance(BaseModel):
 
     colour: Annotated[int, Field(description="Colour (3 bits, 0-7)", ge=0, le=255)]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     mapping: Annotated[int, Field(description="Mapping (4 bits, 0-15)", ge=0, le=255)]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -2978,7 +3056,9 @@ class VehicleSUV(BaseModel):
 
     colour: Annotated[VehicleSUVColour, Field(description="Colour (3 bits, 0-7)")]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     mapping: Annotated[int, Field(description="Mapping (4 bits, 0-15)", ge=0, le=255)]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -3221,7 +3301,9 @@ class VehicleTruck(BaseModel):
 
     colour: Annotated[VehicleTruckColour, Field(description="Colour (3 bits, 0-7)")]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     mapping: Annotated[int, Field(description="Mapping (4 bits, 0-15)", ge=0, le=255)]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -3243,7 +3325,9 @@ class VehicleVan(BaseModel):
 
     colour: Annotated[VehicleVanColour, Field(description="Colour (3 bits, 0-7)")]
     floating: Annotated[bool, Field(description="Floating")]
-    heading: Annotated[Heading, Field(description="Heading / Direction")]
+    heading: Annotated[
+        int, Field(description="ObjectHeading / Direction", ge=0, le=255)
+    ]
     mapping: Annotated[int, Field(description="Mapping (4 bits, 0-15)", ge=0, le=255)]
     xyz: Annotated[ObjectCoordinate, Field(description="Position")]
 
@@ -3461,7 +3545,9 @@ class Cpp(BaseModel):
 
     flags: Annotated[StaFlags, Field(description="State flags to set")]
     fov: Annotated[float, Field(description="Field of View, in degrees")]
-    h: Annotated[Heading, Field(description="heading - 0 points along Y axis")]
+    h: Annotated[
+        int, Field(description="heading - 0 points along Y axis", ge=0, le=65535)
+    ]
     ingamecam: Annotated[CameraView, Field(description="CameraView")]
     p: Annotated[int, Field(description="Pitch", ge=0, le=65535)]
     pos: Annotated[Coordinate, Field(description="Position vector")]
@@ -4300,7 +4386,9 @@ class Con(BaseModel):
     reqi: Annotated[
         int, Field(description="Request identifier echoed by replies.", ge=0, le=255)
     ]
-    spclose: Annotated[Speed, Field(description="Closing speed at impact.")]
+    spclose: Annotated[
+        int, Field(description="Closing speed at impact.", ge=0, le=65535)
+    ]
     time: Annotated[
         int,
         Field(
@@ -4323,7 +4411,9 @@ class Obh(BaseModel):
     reqi: Annotated[
         int, Field(description="Request identifier echoed by replies.", ge=0, le=255)
     ]
-    spclose: Annotated[Speed, Field(description="Closing speed at impact.")]
+    spclose: Annotated[
+        int, Field(description="Closing speed at impact.", ge=0, le=65535)
+    ]
     time: Annotated[
         int,
         Field(

--- a/outgauge/src/lib.rs
+++ b/outgauge/src/lib.rs
@@ -11,7 +11,7 @@ pub use ::insim_core as core;
 use bytes::Buf;
 use insim_core::{
     Decode, DecodeContext, Encode, EncodeContext, dash_lights::DashLights, gear::Gear,
-    identifiers::PlayerId, speed::Speed, vehicle::Vehicle,
+    identifiers::PlayerId, speed::SpeedF32, vehicle::Vehicle,
 };
 
 bitflags::bitflags! {
@@ -104,7 +104,7 @@ pub struct Outgauge {
     /// Currently viewed player
     pub plid: PlayerId,
     /// Speed in m/s
-    pub speed: Speed,
+    pub speed: SpeedF32,
     /// RPM
     pub rpm: f32,
     /// Turbo pressure
@@ -143,7 +143,7 @@ impl Encode for Outgauge {
         ctx.encode("flags", &self.flags)?;
         ctx.encode("gear", &self.gear)?;
         ctx.encode("plid", &self.plid)?;
-        ctx.encode("speed", &self.speed.to_meters_per_sec())?;
+        ctx.encode("speed", &self.speed)?;
         ctx.encode("rpm", &self.rpm)?;
         ctx.encode("turbo", &self.turbo)?;
         ctx.encode("engtemp", &self.engtemp)?;
@@ -171,7 +171,7 @@ impl Decode for Outgauge {
         let flags = ctx.decode::<OutgaugeFlags>("flags")?;
         let gear = ctx.decode::<Gear>("gear")?;
         let plid = ctx.decode::<PlayerId>("plid")?;
-        let speed = Speed::from_meters_per_sec(ctx.decode::<f32>("speed")?);
+        let speed = ctx.decode::<SpeedF32>("speed")?;
         let rpm = ctx.decode::<f32>("rpm")?;
         let turbo = ctx.decode::<f32>("turbo")?;
         let engtemp = ctx.decode::<f32>("engtemp")?;


### PR DESCRIPTION
Decoding everything into human-unit floats was an over-correction when removing the `uom` crate / removing the marker traits: it introduced floating-point issues only resolvable by increasing precision - an endless void of sadness, because it's a representational problem, not a precision one. 

This PR reverts to wire native types and scaling, with an option to break out into human units, more closely aligning to Duration - which makes decode -> encode byte-exact. 

Also fixes three fields (steer/accelf/accelr) that were incorrectly u8.

**Breaking chnages** Prior to this PR several types were lossy. 

Each wire encoding is now a newtype storing the raw version, with human-unit functions
on demand. Decode <-> encode is now lossless.

Removed types:
* Speed, replaced with SpeedF32, SpeedU16, SpeedU8
* Heading, replaced with HeadingU16, HeadingU8
* AngVel, replaced with AngVelI16

Type changes:

| New | Field(s) |
| :--- | :--- |
| SpeedF32 | Outgauge speed |
| SpeedU16 | CompCar speed |
| SpeedU8 | CarContact, ConInfo speed |
| ClosingSpeed | Con, Obh spclose |
| HeadingU16 | CompCar direction, heading, Cpp h |
| HeadingU8 | CarContact, ConInfo direction, heading |
| ObjectHeading | ObjectInfo heading, Jrr spawn |
| AngVelI16 | Compcar angvel |
| i8 | ConInfo steer, accelf, accelr |

Method changes:
- Speed: *_meters_*/*_kilometers_* -> *_metres_*/*_kilometres_*
- Heading::{from,to}_objectinfo_wire -> ObjectHeading::{from,to}_raw.
- AngVel::{from,to}_wire_i16 -> AngVelI16::{from,to}_raw.
- Unchanged: to_degrees/to_radians/to_metres_per_sec/to_degrees_per_sec, normalize, opposite, cardinals.

Behavioural notes:
- Heading to_degrees() now always returns (0, 360); construction wraps (from_degrees(450.0) -> 90), so normalize() is a no-op.
- steer/accelf/accelr reinterpret values 128..255 as negative (correct - braking/left). Same wire bytes.
- serde/schemars now emit the raw integer for scaled types (was float).
- Coordinate::from_*vec3_metres now rounds instead of truncating to whole metres.

Added:
- i8 now implements Decode/Encode.

Unchanged:
- Coordinate/ObjectCoordinate
- Vector
- OutSim/OutGauge/AII float fields
- Cpp pitch/roll

Fixes #408 