### PR TITLE
Correctness and clippy issues

### DIFF
--- a/insim/src/address.rs
+++ b/insim/src/address.rs
@@ -71,3 +71,19 @@ impl From<String> for Addr {
         Self::String(value)
     }
 }
+
+impl Addr {
+    #[cfg(feature = "tokio")]
+    pub(crate) async fn to_socket_addrs_async(&self) -> io::Result<Vec<SocketAddr>> {
+        match self {
+            Self::SocketAddr(addr) => Ok(vec![*addr]),
+            Self::IpAddr(host, port) => Ok(vec![SocketAddr::new(*host, *port)]),
+            Self::String(value) => tokio::net::lookup_host(value.as_str())
+                .await
+                .map(Iterator::collect),
+            Self::Tuple(host, port) => tokio::net::lookup_host((host.as_str(), *port))
+                .await
+                .map(Iterator::collect),
+        }
+    }
+}

--- a/insim/src/builder.rs
+++ b/insim/src/builder.rs
@@ -22,16 +22,30 @@ fn tcpstream_connect_to_any<A: ToSocketAddrs>(
     addrs: A,
     timeout: Duration,
 ) -> std::io::Result<std::net::TcpStream> {
+    let deadline = std::time::Instant::now()
+        .checked_add(timeout)
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "timeout overflow"))?;
+    let mut last_error = None;
     for addr in addrs.to_socket_addrs()? {
-        match std::net::TcpStream::connect_timeout(&addr, timeout) {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "connection timed out",
+            ));
+        }
+        match std::net::TcpStream::connect_timeout(&addr, remaining) {
             Ok(stream) => return Ok(stream),
-            Err(_) => {
-                continue;
-            },
+            Err(error) => last_error = Some(error),
         }
     }
 
-    Err(std::io::Error::other("All connection attempts failed"))
+    Err(last_error.unwrap_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::AddrNotAvailable,
+            "address resolved to no socket addresses",
+        )
+    }))
 }
 
 #[derive(Clone, Debug, Default)]
@@ -324,7 +338,7 @@ impl Builder {
                     stream.set_nonblocking(true)?;
                 }
 
-                let port = self.isi_udpport.unwrap_or(local.port());
+                let port = self.isi_udpport.unwrap_or(stream.local_addr()?.port());
                 let isi = self.isi(Some(port));
 
                 let mut stream: BlockingFramed = stream.into();
@@ -343,10 +357,28 @@ impl Builder {
     pub async fn connect_async(&self) -> Result<AsyncFramed> {
         match self.proto {
             Proto::Tcp => {
-                let stream = tcpstream_connect_to_any(&self.remote, self.connect_timeout)?;
+                let connect = async {
+                    let addrs = self.remote.to_socket_addrs_async().await?;
+                    let mut last_error = None;
+                    for addr in addrs {
+                        match tokio::net::TcpStream::connect(addr).await {
+                            Ok(stream) => return Ok(stream),
+                            Err(error) => last_error = Some(error),
+                        }
+                    }
+                    Err(last_error.unwrap_or_else(|| {
+                        std::io::Error::new(
+                            std::io::ErrorKind::AddrNotAvailable,
+                            "address resolved to no socket addresses",
+                        )
+                    }))
+                };
+                let stream = tokio::time::timeout(self.connect_timeout, connect)
+                    .await
+                    .map_err(|_| {
+                        std::io::Error::new(std::io::ErrorKind::TimedOut, "connection timed out")
+                    })??;
                 stream.set_nodelay(self.tcp_nodelay)?;
-                stream.set_nonblocking(true)?;
-                let stream = tokio::net::TcpStream::from_std(stream)?;
 
                 let mut stream: AsyncFramed = stream.into();
                 stream.write(self.isi(self.isi_udpport)).await?;
@@ -356,13 +388,17 @@ impl Builder {
             Proto::Udp => {
                 let local = self.udp_local_address.unwrap_or("0.0.0.0:0".parse()?);
 
-                let stream = std::net::UdpSocket::bind(local)?;
-                stream.connect(&self.remote)?;
-                stream.set_nonblocking(true)?;
+                let stream = tokio::net::UdpSocket::bind(local).await?;
+                let addrs = self.remote.to_socket_addrs_async().await?;
+                let remote = addrs.into_iter().next().ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::AddrNotAvailable,
+                        "address resolved to no socket addresses",
+                    )
+                })?;
+                stream.connect(remote).await?;
 
-                let stream = tokio::net::UdpSocket::from_std(stream)?;
-
-                let port = self.isi_udpport.unwrap_or(local.port());
+                let port = self.isi_udpport.unwrap_or(stream.local_addr()?.port());
                 let isi = self.isi(Some(port));
 
                 let mut stream: AsyncFramed = stream.into();

--- a/insim/src/insim/ipb.rs
+++ b/insim/src/insim/ipb.rs
@@ -58,6 +58,15 @@ impl Ipb {
     }
 }
 
+impl<'a> IntoIterator for &'a Ipb {
+    type Item = &'a Ipv4Addr;
+    type IntoIter = IndexSetIter<'a, Ipv4Addr>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
 impl Decode for Ipb {
     fn decode(ctx: &mut DecodeContext) -> Result<Self, insim_core::DecodeError> {
         let reqi = ctx.decode::<RequestId>("reqi")?;

--- a/insim/src/insim/mal.rs
+++ b/insim/src/insim/mal.rs
@@ -70,6 +70,15 @@ impl Mal {
     }
 }
 
+impl<'a> IntoIterator for &'a Mal {
+    type Item = &'a Vehicle;
+    type IntoIter = IndexSetIter<'a, Vehicle>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
 impl Decode for Mal {
     fn decode(ctx: &mut DecodeContext) -> Result<Self, insim_core::DecodeError> {
         let reqi = ctx.decode::<RequestId>("reqi")?;

--- a/insim/src/insim/plc.rs
+++ b/insim/src/insim/plc.rs
@@ -208,6 +208,15 @@ impl PlcAllowedCarsSet {
     }
 }
 
+impl<'a> IntoIterator for &'a PlcAllowedCarsSet {
+    type Item = &'a Vehicle;
+    type IntoIter = IndexSetIter<'a, Vehicle>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]

--- a/insim_extra/src/ui/canvas.rs
+++ b/insim_extra/src/ui/canvas.rs
@@ -56,7 +56,7 @@ impl<M: Clone + 'static> std::fmt::Debug for Canvas<M> {
             .field("ucid", &self.ucid)
             .field("buttons", &self.buttons.len())
             .field("click_map", &self.click_map.len())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -73,6 +73,7 @@ impl<M: Clone + 'static> Canvas<M> {
     pub fn reconcile(&mut self, root: Node<M>) -> Option<CanvasDiff> {
         let mut click_map = HashMap::new();
         let mut new_buttons = HashMap::new();
+        let mut pool = self.pool.clone();
 
         let mut tree = taffy::TaffyTree::new();
         let mut node_map = Vec::new();
@@ -83,7 +84,7 @@ impl<M: Clone + 'static> Canvas<M> {
             0,
             self.ucid,
             &self.buttons,
-            &mut self.pool,
+            &mut pool,
             &mut new_buttons,
             &mut tree,
             &mut node_map,
@@ -107,7 +108,7 @@ impl<M: Clone + 'static> Canvas<M> {
 
         // release dead ids
         if !dead_ids.is_empty() {
-            self.pool.release(&dead_ids);
+            pool.release(&dead_ids);
         }
 
         self.click_map = click_map;
@@ -181,6 +182,7 @@ impl<M: Clone + 'static> Canvas<M> {
         }));
 
         self.buttons = new_buttons;
+        self.pool = pool;
 
         if updates.is_empty() && removals.is_empty() {
             None

--- a/insim_extra/src/ui/id_pool.rs
+++ b/insim_extra/src/ui/id_pool.rs
@@ -6,7 +6,7 @@ use insim::identifiers::ClickId;
 /// Helper alias for a Btn ClickId Pool
 pub type ClickIdPool = IdPool<1, 239>;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 /// ClickId Pool - handles allocation and deallocation of unique IDs for buttons
 pub struct IdPool<const MIN: u8, const MAX: u8> {
     // Bit set where 1 = available, 0 = allocated

--- a/insim_extra/src/world/mod.rs
+++ b/insim_extra/src/world/mod.rs
@@ -176,9 +176,17 @@ impl WorldInner {
         });
     }
 
-    fn apply_tiny_clr(&mut self, tiny: &Tiny) {
+    fn apply_tiny_clr(&mut self, tiny: &Tiny) -> Vec<PlayerInfo> {
         if matches!(tiny.subt, TinyType::Clr) {
+            let players = self
+                .players
+                .iter()
+                .map(|(_, player)| player.clone())
+                .collect();
             self.players.clear();
+            players
+        } else {
+            Vec::new()
         }
     }
 
@@ -377,7 +385,10 @@ fn dispatch(inner: &mut WorldInner, packet: &insim::Packet, events: &mut Vec<Wor
             push_race!(inner.apply_telepit(plp));
         },
         Packet::Tiny(tiny) => {
-            inner.apply_tiny_clr(tiny);
+            for player in inner.apply_tiny_clr(tiny) {
+                push_race!(inner.on_player_left(&player));
+                events.push(WorldEvent::PlayerLeft(PlayerLeft(player)));
+            }
             if let Some(prev) = inner.apply_tiny_axc(tiny) {
                 events.push(WorldEvent::LayoutChanged(LayoutChanged {
                     from: Some(prev),
@@ -515,7 +526,7 @@ impl std::fmt::Debug for World {
             .field("session_kind", &g.game.session_kind)
             .field("race_entrants", &g.race.entrants.len())
             .field("rejoin", &g.rejoin)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -779,7 +790,8 @@ impl World {
 mod emission_tests {
     use insim::{
         core::track::Track,
-        insim::{Axi, RaceInProgress, RaceLaps, Rst, Sta},
+        identifiers::{ConnectionId, PlayerId},
+        insim::{Axi, Ncn, Npl, RaceInProgress, RaceLaps, Rst, Sta, Tiny, TinyType},
     };
 
     use super::{World, WorldEvent};
@@ -799,6 +811,58 @@ mod emission_tests {
             count(&events, |e| matches!(e, WorldEvent::SessionStarted(_))),
             1,
             "SessionStarted should fire once on Rst"
+        );
+    }
+
+    #[test]
+    fn tiny_clr_reconciles_players_and_live_race_entrants() {
+        let world = World::new();
+        let _ = world.apply_packet(
+            &Ncn {
+                ucid: ConnectionId(1),
+                uname: "user".into(),
+                pname: "driver".into(),
+                ..Default::default()
+            }
+            .into(),
+        );
+        let _ = world.apply_packet(
+            &Rst {
+                racelaps: RaceLaps::Laps(5),
+                ..Default::default()
+            }
+            .into(),
+        );
+        let _ = world.apply_packet(
+            &Npl {
+                plid: PlayerId(1),
+                ucid: ConnectionId(1),
+                nump: 1,
+                pname: "driver".into(),
+                ..Default::default()
+            }
+            .into(),
+        );
+
+        let events = world.apply_packet(
+            &Tiny {
+                subt: TinyType::Clr,
+                ..Default::default()
+            }
+            .into(),
+        );
+
+        assert_eq!(world.player_count(), 0);
+        assert!(world.live_entrants().is_empty());
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, WorldEvent::PlayerLeft(_)))
+        );
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, WorldEvent::Race(super::RaceEvent::Dnf { .. })))
         );
     }
 


### PR DESCRIPTION
A couple of correctness issues picked up through clippy and some headscratching moments:

  - Isi UDP port incorrectly reported
  - Reconcile players and race entrants on TINY_CLR
  - Use async DNS and connection handling in the Tokio builder
  - Preserve TCP connection errors
  - ClickIdPool leaks after failed canvas reconciliation
  - Missing finish_non_exhaustive on some manual Debug implementations
  - IntoIterator support for Ipb, Mal, and PlcAllowedCarsSet